### PR TITLE
Add Support/ROCapsules

### DIFF
--- a/GameData/KerbalismConfig/Support/ROCapsules.cfg
+++ b/GameData/KerbalismConfig/Support/ROCapsules.cfg
@@ -1,5 +1,6 @@
 // ROCapsules support patches
 // by Gordon Dry
+// (not really, just copied the TAC-LS values 1:1 - so credits go to Frizzank and Pap)
 
 @PART[ROC-MercuryCM]:NEEDS[RealFuels,ROCapsules]:AFTER[ROCapsules]
 {

--- a/GameData/KerbalismConfig/Support/ROCapsules.cfg
+++ b/GameData/KerbalismConfig/Support/ROCapsules.cfg
@@ -1,0 +1,217 @@
+// ROCapsules support patches
+// by Gordon Dry
+
+@PART[ROC-MercuryCM]:NEEDS[RealFuels,ROCapsules]:AFTER[ROCapsules]
+{
+    @description ^= :$: Supports a crew of one for up to maximum 35 hours of active operations but it will require you to change the resources.
+
+    @MODULE[ModuleFuelTanks]
+    {
+        @volume += 61
+
+        TANK
+        {
+            name = Food
+            amount = 0
+            maxAmount = 8.5302
+        }
+
+        TANK
+        {
+            name = Water
+            amount = 0
+            maxAmount = 5.6448
+        }
+
+        TANK
+        {
+            name = Oxygen
+            amount = 0
+            maxAmount = 863.1
+        }
+
+        TANK
+        {
+            name = LithiumHydroxide
+            amount = 1.05
+            maxAmount = 1.05
+        }
+
+        TANK
+        {
+            name = WasteWater
+            amount = 0
+            maxAmount = 7.1820
+        }
+
+        TANK
+        {
+            name = Waste
+            amount = 0
+            maxAmount = 5.7305
+        }
+
+        TANK
+        {
+            name = CarbonDioxide
+            amount = 0
+            maxAmount = 380
+        }
+    }
+}
+
+@PART[ROC-ApolloCM]:NEEDS[RealFuels,ROCapsules]:AFTER[ROCapsules]
+{
+    @description ^= :$: Supports a crew of three for up to 14 days of active operations.
+
+    @mass -= 0.15
+
+    @MODULE[ModuleFuelTanks]
+    {
+        @volume += 380
+
+        TANK
+        {
+            name = Food
+            amount = 245.7
+            maxAmount = 245.7
+        }
+
+        //  One water storage tank with a capacity of ~16 kg.
+        TANK
+        {
+            name = Water
+            amount = 16
+            maxAmount = 16
+        }
+
+        TANK
+        {
+            name = Oxygen
+            amount = 1755.5
+            maxAmount = 1755.5
+        }
+
+        TANK
+        {
+            name = LithiumHydroxide
+            amount = 43.2
+            maxAmount = 43.2
+        }
+
+        //  One waste water tank with a capacity of ~25 kg.
+        TANK
+        {
+            name = WasteWater
+            amount = 0
+            maxAmount = 25
+        }
+
+        TANK
+        {
+            name = Waste
+            amount = 0
+            maxAmount = 22.4
+        }
+
+        TANK
+        {
+            name = CarbonDioxide
+            amount = 0
+            maxAmount = 1534.5
+        }
+    }
+}
+
+@PART[ROC-LEMAscent]:NEEDS[RealFuels,ROCapsules]:AFTER[ROCapsules]
+{
+    @description ^= :$: Supports a crew of two for up to 3 days of active operations.
+
+    @mass -= 0.04
+
+    @MODULE[ModuleFuelTanks]
+    {
+        @volume += 165
+
+        TANK
+        {
+            name = Food
+            amount = 23.4
+            maxAmount = 35.1
+        }
+
+        //  Two water tanks with a capacity of ~20 kg each.
+
+        TANK
+        {
+            name = Water
+            amount = 40
+            maxAmount = 40
+        }
+
+        //  Two oxygen tanks with a capacity of ~1.1 kg each.
+
+        TANK
+        {
+            name = Oxygen
+            amount = 1563.4
+            maxAmount = 1563.4
+        }
+
+        TANK
+        {
+            name = LithiumHydroxide
+            amount = 4.1
+            maxAmount = 6.2
+        }
+
+        TANK
+        {
+            name = Waste
+            amount = 0
+            maxAmount = 3.2
+        }
+
+        TANK
+        {
+            name = WasteWater
+            amount = 0
+            maxAmount = 29.3
+        }
+
+        TANK
+        {
+            name = CarbonDioxide
+            amount = 0
+            maxAmount = 1023
+        }
+    }
+}
+
+@PART[ROC-LEMDescent]:NEEDS[RealFuels,ROCapsules]:AFTER[ROCapsules]
+{
+    @mass -= 0.194
+
+    @MODULE[ModuleFuelTanks]
+    {
+        @volume += 310
+
+        //  Two water tanks with a capacity of ~75 kg each (second tank for J missions).
+
+        TANK
+        {
+            name = Water
+            amount = 0
+            maxAmount = 150
+        }
+
+        //  Two oxygen tanks with a capacity of ~22 kg each (second tank for J missions).
+
+        TANK
+        {
+            name = Oxygen
+            amount = 15441.4
+            maxAmount = 30882.9
+        }
+    }
+}


### PR DESCRIPTION
added
Support/ROCapsules.cfg

because the RealFuels' ModuleFuelTanks have only been patched for TAC-LS before.