### PR TITLE
Remove ModuleScienceContainer

### DIFF
--- a/GameData/KerbalismConfig/System/Science/HardDriveConfigs.cfg
+++ b/GameData/KerbalismConfig/System/Science/HardDriveConfigs.cfg
@@ -1,3 +1,9 @@
+// missed this one
+@PART[*]:HAS[@MODULE[ModuleScienceContainer]]:NEEDS[FeatureScience]
+{
+	!MODULE[ModuleScienceContainer] {}
+}
+
 // ============================================================================
 // KERBALISM_HDD_SIZES - Temporary tweaking values
 // ============================================================================

--- a/GameData/KerbalismConfig/System/Science/HardDriveConfigs.cfg
+++ b/GameData/KerbalismConfig/System/Science/HardDriveConfigs.cfg
@@ -229,7 +229,7 @@ KERBALISM_HDD_SIZES
 // ============================================================================
 
 // missed this one
-@PART[*]:HAS[@MODULE[ModuleScienceContainer]]:NEEDS[FeatureScience]
+@PART[*]:HAS[@MODULE[ModuleScienceContainer]]:NEEDS[FeatureScience,RP-0]:FOR[RP-0-Kerbalism]
 {
 	!MODULE[ModuleScienceContainer] {}
 }

--- a/GameData/KerbalismConfig/System/Science/HardDriveConfigs.cfg
+++ b/GameData/KerbalismConfig/System/Science/HardDriveConfigs.cfg
@@ -1,9 +1,3 @@
-// missed this one
-@PART[*]:HAS[@MODULE[ModuleScienceContainer]]:NEEDS[FeatureScience]
-{
-	!MODULE[ModuleScienceContainer] {}
-}
-
 // ============================================================================
 // KERBALISM_HDD_SIZES - Temporary tweaking values
 // ============================================================================
@@ -234,6 +228,11 @@ KERBALISM_HDD_SIZES
 // modded parts will need separate tweaks in their own configs
 // ============================================================================
 
+// missed this one
+@PART[*]:HAS[@MODULE[ModuleScienceContainer]]:NEEDS[FeatureScience]
+{
+	!MODULE[ModuleScienceContainer] {}
+}
 
 @PART[*]:HAS[@MODULE[ModuleCommand]:HAS[~name[!proceduralAvionics]]]:NEEDS[FeatureScience,RP-0]:FOR[RP-0-Kerbalism]
 {


### PR DESCRIPTION
This is forgotten, stock Kerbalism also does this in favor of MODULE[HardDrive]