### PR TITLE
Fix MM errors for missing variables

### DIFF
--- a/GameData/KerbalismConfig/System/Science/CrewScience/ExperimentValues.cfg
+++ b/GameData/KerbalismConfig/System/Science/CrewScience/ExperimentValues.cfg
@@ -5,6 +5,7 @@ KERBALISM_CREW_EXPERIMENTS
 	{
 		ECCost = 0.01
 		size = 0.02
+                SampleMass = 0 // a file, not a sample
 		value = 8
 		duration = 10800 //3 hours
 		requirements = 
@@ -15,6 +16,7 @@ KERBALISM_CREW_EXPERIMENTS
 	{
         ECCost = 0
 		size =  0.005
+                SampleMass = 0 // a file, not a sample
 		value = 16
 		duration = 14400 //4 hours
 		requirements = 
@@ -25,6 +27,7 @@ KERBALISM_CREW_EXPERIMENTS
     {
         ECCost = 0.01
 		size =  0.01
+                SampleMass = 0 // a file, not a sample
 		value = 10
 		duration = 10800 //3 hours
 		requirements = 
@@ -47,6 +50,7 @@ KERBALISM_CREW_EXPERIMENTS
     {
         ECCost = 0.05
         size =  0.005
+                SampleMass = 0 // a file, not a sample
 		value = 16
 		duration = 10800 //3 hours
 		requirements = CrewMin:2
@@ -57,6 +61,7 @@ KERBALISM_CREW_EXPERIMENTS
 	{
         ECCost = 0
         size =  0.005
+                SampleMass = 0 // a file, not a sample
 		value = 24
 		duration = 21600 //6 hours
 		requirements = CrewMin:2
@@ -67,6 +72,7 @@ KERBALISM_CREW_EXPERIMENTS
 	{
         ECCost = 0.002
         size =  0.3
+                SampleMass = 0 // a file, not a sample
 		value = 40
 		duration = 172800 //48 hours
 		requirements = CrewMin:2
@@ -77,6 +83,7 @@ KERBALISM_CREW_EXPERIMENTS
 	{
         ECCost = 0.1
         size =  0.2
+                SampleMass = 0 // a file, not a sample
 		value = 40
 		duration = 172800 //48 hours
 		requirements = CrewMin:2,AstronautComplexLevelMin:2
@@ -109,6 +116,7 @@ KERBALISM_CREW_EXPERIMENTS
 	{
         ECCost = 0
         size =  0.5
+                SampleMass = 0 // a file, not a sample
 		value = 20
 		duration = 518400 //144 hours
 		requirements = CrewMin:2
@@ -119,6 +127,7 @@ KERBALISM_CREW_EXPERIMENTS
 	{
         ECCost = 0
         size =  0.001
+                SampleMass = 0 // a file, not a sample
 		value = 5
 		duration = 3600 //1 hours
 		requirements = CrewMin:2
@@ -129,6 +138,7 @@ KERBALISM_CREW_EXPERIMENTS
 	{
         ECCost = 0
         size =  0.002
+                SampleMass = 0 // a file, not a sample
 		value = 10
 		duration = 7200 //2 hours
 		requirements = CrewMin:2,AstronautComplexLevelMin:2
@@ -139,6 +149,7 @@ KERBALISM_CREW_EXPERIMENTS
 	{
         ECCost = 0.01
         size =  0.172
+                SampleMass = 0 // a file, not a sample
 		value = 30
 		duration = 86400 //24 hours
 		requirements = CrewMin:2
@@ -160,6 +171,7 @@ KERBALISM_CREW_EXPERIMENTS
 	{
         ECCost = 0.01
         size =  0.0324
+                SampleMass = 0 // a file, not a sample
 		value = 30
 		duration = 86400 //24 hours
 		requirements = CrewMin:2
@@ -171,6 +183,7 @@ KERBALISM_CREW_EXPERIMENTS
 	{
         ECCost = 0.0175
         size =  36 //40 kb/s
+                SampleMass = 0 // a file, not a sample
 		value = 40
 		duration = 7200 //2 hours
 		requirements = CrewMin:3
@@ -181,6 +194,7 @@ KERBALISM_CREW_EXPERIMENTS
 	{
         ECCost = 0.02
         size =  21.6 //1 kb/s
+                SampleMass = 0 // a file, not a sample
 		value = 30
 		duration = 172800 //48 hours
 		requirements = CrewMin:2
@@ -191,6 +205,7 @@ KERBALISM_CREW_EXPERIMENTS
 	{
         ECCost = 0.018
         size =  27 //5 kb/s
+                SampleMass = 0 // a file, not a sample
 		value = 15
 		duration = 43200 //12 hours
 		requirements = CrewMin:2

--- a/GameData/KerbalismConfig/System/Science/SatelliteScience/ExperimentValues.cfg
+++ b/GameData/KerbalismConfig/System/Science/SatelliteScience/ExperimentValues.cfg
@@ -19,6 +19,7 @@ KERBALISM_EXPERIMENT_VALUES
 	{
 		ECCost = 0.0001
 		size = 0.00005625 //1.5 b/s
+                SampleMass = 0 // a file, not a sample
 		value = 3
 		duration = 300 //5 minutes
 		requirements = 
@@ -28,6 +29,7 @@ KERBALISM_EXPERIMENT_VALUES
 	{
 		ECCost = 0.0001
 		size = 0.0007875 //3.5 b/s
+                SampleMass = 0 // a file, not a sample
 		value = 10
 		duration = 1800 //30 minutes
 		requirements = SurfaceSpeedMin:343//,Atmosphere
@@ -39,6 +41,7 @@ KERBALISM_EXPERIMENT_VALUES
 	{
 		ECCost = 0.001
 		size = 0.000075 //1 b/s
+                SampleMass = 0 // a file, not a sample
 		value = 4
 		duration = 600 //10 minutes
 		requirements = 
@@ -50,6 +53,7 @@ KERBALISM_EXPERIMENT_VALUES
 	{
 		ECCost = 0.001
 		size = 0.000075 //1 b/s
+                SampleMass = 0 // a file, not a sample
 		value = 4
 		duration = 600 //10 minutes
 		requirements =
@@ -133,6 +137,7 @@ KERBALISM_EXPERIMENT_VALUES
 	{
 		ECCost = 2.1  //Hubble uses 2.1 kW on average
 		size = 18720000 //Hubble sends an average of 18 GB of data per week
+                SampleMass = 0 // a file, not a sample
 		value = 10000 //500 science per year
 		duration = 630720000 //20 years, HST has been operating for almost 30 years
 		requirements = Body:Earth,OrbitMaxEccentricity:0.001,AltitudeMin:350000,RadiationMax:0.005//,PlanetarySpace
@@ -144,6 +149,7 @@ KERBALISM_EXPERIMENT_VALUES
 	{
 		ECCost = 0.0
 		size = 0.005
+                SampleMass = 0 // a file, not a sample
 		value = 4
 		duration = 300 //5 minutes
 		requirements = 
@@ -153,6 +159,7 @@ KERBALISM_EXPERIMENT_VALUES
 	{
 		ECCost = 0.02
 		size = 1
+                SampleMass = 0 // a file, not a sample
 		value = 15
 		duration = 1209600 //14 days
 		requirements = 
@@ -164,6 +171,7 @@ KERBALISM_EXPERIMENT_VALUES
 	{
 		ECCost = 0.0
 		size = 0.5
+                SampleMass = 0 // a file, not a sample
 		value = 24
 		duration = 300 //5 minutes
 		requirements = 
@@ -183,6 +191,7 @@ KERBALISM_EXPERIMENT_VALUES
 	{
 		ECCost = 0.1
 		size = 0.5
+                SampleMass = 0 // a file, not a sample
 		value = 6
 		duration = 300 //5 minutes
 		requirements = //Surface
@@ -194,6 +203,7 @@ KERBALISM_EXPERIMENT_VALUES
 	{
 		ECCost = 0.002
 		size = 0.001
+                SampleMass = 0 // a file, not a sample
 		value = 8
 		duration = 7200 //2 hours
 		requirements =
@@ -203,6 +213,7 @@ KERBALISM_EXPERIMENT_VALUES
 	{
 		ECCost = 0.005
 		size = 0.01
+                SampleMass = 0 // a file, not a sample
 		value = 12
 		duration = 1209600 //14 days
 		requirements = OrbitMinEccentricity:0.1
@@ -212,6 +223,7 @@ KERBALISM_EXPERIMENT_VALUES
 	{
 		ECCost = 0.01
 		size = 0.1
+                SampleMass = 0 // a file, not a sample
 		value = 20
 		duration = 7862400 //3 months
 		requirements = OrbitMinEccentricity:0.1
@@ -221,6 +233,7 @@ KERBALISM_EXPERIMENT_VALUES
 	{
 		ECCost = 0.06
 		size = 884.52 // 0.9 kbps
+                SampleMass = 0 // a file, not a sample
 		value = 30
 		duration = 7862400 //3 months
 		requirements =
@@ -232,6 +245,7 @@ KERBALISM_EXPERIMENT_VALUES
 	{
 		ECCost = 0.0001
 		size = 1.9656 //2 b/s
+                SampleMass = 0 // a file, not a sample
 		value = 10
 		duration = 7862400 //3 months
 		requirements = OrbitMinEccentricity:0.04
@@ -241,6 +255,7 @@ KERBALISM_EXPERIMENT_VALUES
 	{
 		ECCost = 0.002
 		size = 39 //5 byte/s
+                SampleMass = 0 // a file, not a sample
 		value = 30
 		duration = 7862400 //3 months
 		requirements = 
@@ -252,6 +267,7 @@ KERBALISM_EXPERIMENT_VALUES
 	{
 		ECCost = 0
 		size = 0.4914 //0.5 b/s
+                SampleMass = 0 // a file, not a sample
 		value = 7
 		duration = 7862400 //3 months
 		requirements = OrbitMinEccentricity:0.04
@@ -263,6 +279,7 @@ KERBALISM_EXPERIMENT_VALUES
 	{
 		ECCost = 0.006
 		size = 2.6208 //1 byte/s
+                SampleMass = 0 // a file, not a sample
 		value = 6
 		duration = 2620800 //1 month
 		requirements = 
@@ -272,6 +289,7 @@ KERBALISM_EXPERIMENT_VALUES
 	{
 		ECCost = 0.0073
 		size = 39.312 //15 byte/s
+                SampleMass = 0 // a file, not a sample
 		value = 12
 		duration = 2620800 //1 month
 		requirements = 
@@ -281,6 +299,7 @@ KERBALISM_EXPERIMENT_VALUES
 	{
 		ECCost = 0.002
 		size = 118 //15 byte/s
+                SampleMass = 0 // a file, not a sample
 		value = 40
 		duration = 7862400 //3 month
 		requirements = 
@@ -292,6 +311,7 @@ KERBALISM_EXPERIMENT_VALUES
 	{
 		ECCost = 0.016
 		size = 3685 //468 byte/s
+                SampleMass = 0 // a file, not a sample
 		value = 3
 		duration = 7862400 //3 months
 		requirements = AltitudeMax:4000000
@@ -301,6 +321,7 @@ KERBALISM_EXPERIMENT_VALUES
 	{
 		ECCost = 0.004
 		size = 4717 //600 byte/s
+                SampleMass = 0 // a file, not a sample
 		value = 3
 		duration = 7862400 //3 months
 		requirements = 
@@ -310,6 +331,7 @@ KERBALISM_EXPERIMENT_VALUES
 	{
 		ECCost = 0.012
 		size = 11322 //1.44 Kilobyte/s
+                SampleMass = 0 // a file, not a sample
 		value = 4
 		duration = 7862400 //3 months
 		requirements = 
@@ -321,6 +343,7 @@ KERBALISM_EXPERIMENT_VALUES
 	{
 		ECCost = 0.005
 		size = 0.0003 //2 bit/s
+                SampleMass = 0 // a file, not a sample
 		value = 1.5
 		duration = 1200 //20 minutes
 		requirements = 
@@ -330,6 +353,7 @@ KERBALISM_EXPERIMENT_VALUES
 	{
 		ECCost = 0.008
 		size = 0.648 //180 byte/s
+                SampleMass = 0 // a file, not a sample
 		value = 2
 		duration = 3600 //1 hour
 		requirements = 
@@ -339,6 +363,7 @@ KERBALISM_EXPERIMENT_VALUES
 	{
 		ECCost = 0.031
 		size = 19.8 //2.75 Kilobyte/s
+                SampleMass = 0 // a file, not a sample
 		value = 3
 		duration = 7200 //2 hours
 		requirements = 
@@ -350,6 +375,7 @@ KERBALISM_EXPERIMENT_VALUES
 	{
 		ECCost = 0.002
 		size = 315.36 //1 byte/s
+                SampleMass = 0 // a file, not a sample
 		value = 300
 		duration = 315360000 //10 years
 		requirements = //Microgravity
@@ -361,6 +387,7 @@ KERBALISM_EXPERIMENT_VALUES
 	{
 		ECCost = 0.0024
 		size = 0.6912 //8 byte/s
+                SampleMass = 0 // a file, not a sample
 		value = 2
 		duration = 86400 //1 day
 		requirements = 
@@ -370,6 +397,7 @@ KERBALISM_EXPERIMENT_VALUES
 	{
 		ECCost = 0.004
 		size = 12.96//20 byte/s
+                SampleMass = 0 // a file, not a sample
 		value = 3
 		duration = 604800 //1 week
 		requirements = 
@@ -379,6 +407,7 @@ KERBALISM_EXPERIMENT_VALUES
 	{
 		ECCost = 0.0025
 		size = 65.8 //25 byte/s
+                SampleMass = 0 // a file, not a sample
 		value = 4
 		duration = 2592000 //1 month
 		requirements = 
@@ -390,6 +419,7 @@ KERBALISM_EXPERIMENT_VALUES
 	{
 		ECCost = 0.002
 		size = 7 //11.5 byte/s
+                SampleMass = 0 // a file, not a sample
 		value = 15
 		duration = 604800 //1 week
 		requirements = 
@@ -399,6 +429,7 @@ KERBALISM_EXPERIMENT_VALUES
 	{
 		ECCost = 0.005
 		size = 103.68 //40 byte/s
+                SampleMass = 0 // a file, not a sample
 		value = 20
 		duration = 2592000 //1 month
 		requirements = 
@@ -408,6 +439,7 @@ KERBALISM_EXPERIMENT_VALUES
 	{
 		ECCost = 0.007
 		size = 1749.6 //112.5 byte/s
+                SampleMass = 0 // a file, not a sample
 		value = 30
 		duration = 15552000 //6 months
 		requirements = 


### PR DESCRIPTION
Recent commit added a bunch of lines like this:
SampleMass = #$@KERBALISM_CREW_EXPERIMENTS/RP0-FlightControl/SampleMass

But the corresponding objects in ExperimentValues.cfg mostly don't have
a SampleMass field, and this causes a MM error
("cannot parse variable search").

per Got: added a SampleMass=0 field to non-sample experiments.

Alternate fix is to remove SampleMass from the KERBALISM_EXPERIMENT
nodes; not obvious to me which is preferable, so I went with the
option that involved editing fewer files.