### PR TITLE
Move fuel cell tech unlocks to Power nodes

### DIFF
--- a/GameData/KerbalismConfig/Profiles/ROKerbalism.cfg
+++ b/GameData/KerbalismConfig/Profiles/ROKerbalism.cfg
@@ -733,7 +733,7 @@ Supply
 	{
 		name = Acid IEM Fuel Cell
 		desc = Combines <b>LqdHydrogen</b> and <b>LqdOxygen</b> to produce <b>Water</b> and <b>Electricity</b>.
-		tech = earlyLifeSupport
+		tech = improvedPower
 		mass = 0.10
 		cost = 200 //FIXME
 
@@ -749,7 +749,7 @@ Supply
     {
       name = Apollo alkaline Fuel Cell
       desc = Combines <b>LqdHydrogen</b> and <b>LqdOxygen</b> to produce <b>Water</b> and <b>Electricity</b>.
-      tech = lifeSupportISRU
+      tech = lunarRatedPower
       mass = 0.075
       cost = 200 //FIXME
 	  
@@ -765,7 +765,7 @@ Supply
     {
       name = Shuttle alkaline Fuel Cell
       desc = Combines <b>LqdHydrogen</b> and <b>LqdOxygen</b> to produce <b>Water</b> and <b>Electricity</b>.
-      tech = improvedLifeSupport
+      tech = maturePower
       mass = 0.015
       cost = 200 //FIXME
 
@@ -822,7 +822,7 @@ Supply
 	{
 		name = Acid IEM Fuel Cell
 		desc = Combines <b>LqdHydrogen</b> and <b>LqdOxygen</b> to produce <b>Water</b> and <b>Electricity</b>.
-		tech = earlyLifeSupport
+		tech = improvedPower
 		mass = 0.075
 		cost = 150 //FIXME
 
@@ -838,7 +838,7 @@ Supply
     {
       name = Apollo alkaline Fuel Cell
       desc = Combines <b>LqdHydrogen</b> and <b>LqdOxygen</b> to produce <b>Water</b> and <b>Electricity</b>.
-      tech = lifeSupportISRU
+      tech = lunarRatedPower
       mass = 0.05625
       cost = 150 //FIXME
 	  
@@ -854,7 +854,7 @@ Supply
     {
       name = Shuttle alkaline Fuel Cell
       desc = Combines <b>LqdHydrogen</b> and <b>LqdOxygen</b> to produce <b>Water</b> and <b>Electricity</b>.
-      tech = improvedLifeSupport
+      tech = maturePower
       mass = 0.01125
       cost = 150 //FIXME
 
@@ -911,7 +911,7 @@ Supply
 	{
 		name = Acid IEM Fuel Cell
 		desc = Combines <b>LqdHydrogen</b> and <b>LqdOxygen</b> to produce <b>Water</b> and <b>Electricity</b>.
-		tech = earlyLifeSupport
+		tech = improvedPower
 		mass = 0.55
 		cost = 800 //FIXME
 
@@ -927,7 +927,7 @@ Supply
     {
       name = Apollo alkaline Fuel Cell
       desc = Combines <b>LqdHydrogen</b> and <b>LqdOxygen</b> to produce <b>Water</b> and <b>Electricity</b>.
-      tech = lifeSupportISRU
+      tech = lunarRatedPower
       mass = 0.4125
       cost = 800 //FIXME
 	  
@@ -943,7 +943,7 @@ Supply
     {
       name = Shuttle alkaline Fuel Cell
       desc = Combines <b>LqdHydrogen</b> and <b>LqdOxygen</b> to produce <b>Water</b> and <b>Electricity</b>.
-      tech = improvedLifeSupport
+      tech = maturePower
       mass = 0.0825
       cost = 800 //FIXME
 


### PR DESCRIPTION
That's where the actual fuel cell parts are. Fuel cells are often
used for life support, but aren't inherently related to life support.

As a side-effect, this means a Gemini capsule still has to research
the fuel cell Power node to be able to use its built-in fuel cells,
putting it on equal footing with a capsule without built-in cells
(like the RO Advanced Capsule)