### PR TITLE
Make probe core experiments removable early-game

### DIFF
--- a/GameData/KerbalismConfig/System/Science/Configure.cfg
+++ b/GameData/KerbalismConfig/System/Science/Configure.cfg
@@ -131,6 +131,30 @@
 			name = None
 			desc = Empty slot for mass and cost savings, should you not require any experiments installed.
 		}
+		// More None entries because kerbalism only makes slots
+        // configurable if there are more "valid" entries than slots.
+        // Thermometer and barometer are always unlocked in RP-1,
+        // we have 4 slots, so need 3 None entries (total 5) to make
+        // thermo and baro unselectable in the early game.
+        // (presumably a kerbalism core bug)
+        // Must have unique names, otherwise kerbalism gets confused.
+        // Ugly workaround, means user will have 2 extra useless
+        // entries to cycle through.
+		SETUP
+		{
+			name = None 2
+			desc = Empty slot 2
+		}
+		SETUP
+		{
+			name = None 3
+			desc = Empty slot 3
+		}
+		SETUP
+		{
+			name = None 4
+			desc = Empty slot 4
+		}
 		SETUP
 		{
 			name = Barometer
@@ -420,25 +444,6 @@
 			  id_field = experiment_id
 			  id_value = RP0imageSpec3
 			}
-		}
-                // More None entries because kerbalism only makes slots
-                // configurable if there are more "valid" entries than slots.
-                // Thermometer and barometer are always unlocked in RP-1,
-                // we have 4 slots, so need 3 None entries (total 5) to make
-                // thermo and baro unselectable in the early game.
-                // (presumably a kerbalism core bug)
-                // Must have unique names, otherwise kerbalism gets confused.
-                // Ugly workaround, means user will have 2 extra useless
-                // entries to cycle through.
-		SETUP
-		{
-			name = None 2
-			desc = Empty slot 2
-		}
-		SETUP
-		{
-			name = None 3
-			desc = Empty slot 3
 		}
 	}
 }

--- a/GameData/KerbalismConfig/System/Science/Configure.cfg
+++ b/GameData/KerbalismConfig/System/Science/Configure.cfg
@@ -126,7 +126,6 @@
 		name = Configure
 		title = Experiments
 		slots = 4
-		
 		SETUP
 		{
 			name = None
@@ -421,6 +420,25 @@
 			  id_field = experiment_id
 			  id_value = RP0imageSpec3
 			}
+		}
+                // More None entries because kerbalism only makes slots
+                // configurable if there are more "valid" entries than slots.
+                // Thermometer and barometer are always unlocked in RP-1,
+                // we have 4 slots, so need 3 None entries (total 5) to make
+                // thermo and baro unselectable in the early game.
+                // (presumably a kerbalism core bug)
+                // Must have unique names, otherwise kerbalism gets confused.
+                // Ugly workaround, means user will have 2 extra useless
+                // entries to cycle through.
+		SETUP
+		{
+			name = None 2
+			desc = Empty slot 2
+		}
+		SETUP
+		{
+			name = None 3
+			desc = Empty slot 3
 		}
 	}
 }


### PR DESCRIPTION
Workaround for presumed Core bug: if there are fewer available
experiments than slots, the default-selected experiments can't be
deselected. So add a couple of dummy entries.