### PR TITLE
Fix Prototype Spaceplane habitat size

### DIFF
--- a/GameData/KerbalismConfig/System/Habitat.cfg
+++ b/GameData/KerbalismConfig/System/Habitat.cfg
@@ -98,13 +98,13 @@
 		max_pressure = 0.34
 	}
 }
-@PART[RO-Mk1Cockpit,RO-Mk1CockpitInline]:NEEDS[FeatureHabitat]:AFTER[Kerbalism]
+@PART[RO-Mk1Cockpit,RO-Mk1CockpitInline]:NEEDS[FeatureHabitat]:AFTER[RealismOverhaul]
 {
 	@MODULE[Habitat]
 	{
-		volume = 2.32       //guesstimate
-		surface = 6.01      //guesstimate
-		max_pressure = 0.35
+		%volume = 2.32       //guesstimate
+		%surface = 6.01      //guesstimate
+		%max_pressure = 0.35
 	}
 }
 @PART[FASAGeminiPod2,FASAGeminiPod2White,ROAdvCapsule]:NEEDS[FeatureHabitat]:AFTER[Kerbalism]


### PR DESCRIPTION
Apply the patch :after[RO], because the parts get created in :for[RO]
(I didn't think it mattered for +patches, but without this the patch
never gets applied)

Also use %, in case the 1.25m part gets patched before the +part[]
clones it. (not sure this is needed, was the 1st thing I tried and it
wasn't enough. can't hurt)