### PR TITLE
Correct capsule power draw to account for LS

### DIFF
--- a/GameData/KerbalismConfig/System/Comfort.cfg
+++ b/GameData/KerbalismConfig/System/Comfort.cfg
@@ -29,7 +29,7 @@
 }
 
 
-@PART[crewCabin|SXTISSHabISK30|Large_Crewed_Lab|STXCANIOT|InflatableHAB|SXTSPKTRCabin|SXTDLK83EHabitat]:NEEDS[FeatureComfort]:FOR[Kerbalism]
+@PART[crewCabin|SXTISSHabISK30|Large_Crewed_Lab|STXCANIOT|InflatableHAB|SXTSPKTRCabin|SXTDLK83EHabitat|skylab]:NEEDS[FeatureComfort]:FOR[Kerbalism]
 {
   MODULE
   {

--- a/GameData/KerbalismConfig/System/Parts.cfg
+++ b/GameData/KerbalismConfig/System/Parts.cfg
@@ -28,6 +28,13 @@
 // well established.
 @PART[Mark2Cockpit]:NEEDS[ProfileRealismOverhaul]:AFTER[RealismOverhaul]
 {
+	@MODULE[ModuleCommand]
+	{
+		@RESOURCE[ElectricCharge]
+		{
+			@rate = 1.520	//Remove Climatization and LS power draw
+		}
+	}
   // uses an EVA scrubber because x-15's life support was just a rudimentary
   // suit so it's assumed to have a small airflow and be very simple
   MODULE
@@ -64,6 +71,13 @@
 //Mercury
 @PART[ROC-MercuryCM|FASAMercuryPod|mk1pod|mk1pod_v2]:NEEDS[ProfileRealismOverhaul]:AFTER[RealismOverhaul]
 {
+	@MODULE[ModuleCommand]
+	{
+		@RESOURCE[ElectricCharge]
+		{
+			@rate = 0.475	//Remove Climatization and LS power draw
+		}
+	}
   MODULE
   {
     name = ProcessController
@@ -105,6 +119,13 @@
 //Vostok/Voskhod
 @PART[kv3Pod|ROC-VostokCapsule|ROC-VoskhodCapsule|rn_vostok_sc|rn_voskhod_sc]:NEEDS[ProfileRealismOverhaul]:AFTER[RealismOverhaul]
 {
+	@MODULE[ModuleCommand]
+	{
+		@RESOURCE[ElectricCharge]
+		{
+			@rate = 0.214	//Remove Climatization and LS power draw
+		}
+	}
   MODULE
   {
     name = ProcessController
@@ -186,6 +207,13 @@
 //Descent module
 @PART[rn_zond_sa|ok_sa|rn_lok_sa|SSTU-SC-A-DM]:NEEDS[ProfileRealismOverhaul]:AFTER[RealismOverhaul]
 {
+	@MODULE[ModuleCommand]
+	{
+		@RESOURCE[ElectricCharge]
+		{
+			@rate = 0.650	//Remove Climatization and LS power draw
+		}
+	}
   MODULE
   {
     name = ProcessController
@@ -306,6 +334,14 @@
 //Gemini
 @PART[Mk2Pod|FASAGeminiPod2|FASAGeminiPod2White|ROAdvCapsule]:NEEDS[ProfileRealismOverhaul]:AFTER[RealismOverhaul]
 {
+
+	@MODULE[ModuleCommand]
+	{
+		@RESOURCE[ElectricCharge]
+		{
+			@rate = 1.900	//Remove Climatization and LS power draw
+		}
+	}
   MODULE
   {
     name = ProcessController
@@ -345,6 +381,13 @@
 //Early Spaceplanes
 @PART[RO-Mk1Cockpit|RO-Mk1CockpitInline|MK1CrewCabin]:NEEDS[ProfileRealismOverhaul]:AFTER[RealismOverhaul]
 {
+	@MODULE[ModuleCommand]
+	{
+		@RESOURCE[ElectricCharge]
+		{
+			@rate = 0.360	//Remove Climatization and LS power draw
+		}
+	}
 	MODULE
   {
     name = ProcessController
@@ -432,6 +475,13 @@
 //Early Landers
 @PART[landerCabinSmall|FASA_Gemini_Lander_Pod]:NEEDS[ProfileRealismOverhaul]:AFTER[RealismOverhaul]
 {
+	@MODULE[ModuleCommand]
+	{
+		@RESOURCE[ElectricCharge]
+		{
+			@rate = 0.327	//Remove Climatization and LS power draw
+		}
+	}
   MODULE
   {
     name = ProcessController
@@ -472,6 +522,13 @@
 //Apollo
 @PART[APOLLO_CM|FASAApollo_CM|bluedog_Apollo_Block2_Capsule|ROC-ApolloCM|SSTU-SC-B-CM|SSTU-SC-B-CMX|mk1-3pod]:NEEDS[ProfileRealismOverhaul]:AFTER[RealismOverhaul]
 {
+	@MODULE[ModuleCommand]
+	{
+		@RESOURCE[ElectricCharge]
+		{
+			@rate = 1.520	//Remove Climatization and LS power draw
+		}
+	}
   MODULE
   {
     name = ProcessController
@@ -550,6 +607,13 @@
 //Landers
 @PART[ROC-LEMAscent|LEM_ASCENT_STAGE|FASALM_AscentStage|bluedog_LEM_Ascent_Cockpit|landerCabinMedium|mk2LanderCan|mk2LanderCabin_v2|SXTLander|SSTU-LC2-POD|rn_lk_lander]:NEEDS[ProfileRealismOverhaul]:AFTER[RealismOverhaul]
 {
+	@MODULE[ModuleCommand]
+	{
+		@RESOURCE[ElectricCharge]
+		{
+			@rate -= 0.2	//Remove Climatization and LS power draw
+		}
+	}
   MODULE
   {
     name = ProcessController
@@ -639,6 +703,13 @@
 //Apollo Block III
 @PART[bluedog_Apollo_Block3_Capsule]:NEEDS[ProfileRealismOverhaul]:AFTER[RealismOverhaul]
 {
+	@MODULE[ModuleCommand]
+	{
+		@RESOURCE[ElectricCharge]
+		{
+			@rate -= 0.400	//Remove Climatization and LS power draw
+		}
+	}
   MODULE
   {
     name = ProcessController
@@ -680,6 +751,13 @@
 //VA capsule
 @PART[MK2VApod|rn_va_capsule|SSTU-SC-V-CM]:NEEDS[ProfileRealismOverhaul]:AFTER[RealismOverhaul]
 {
+	@MODULE[ModuleCommand]
+	{
+		@RESOURCE[ElectricCharge]
+		{
+			@rate = 1.500	//Remove Climatization and LS power draw
+		}
+	}
   MODULE
   {
     name = ProcessController


### PR DESCRIPTION
Decrease the base power draw of crewed parts to account for Kerbalism LS increasing draw, and prevent the player from being "charged twice" for life support.