### PR TITLE
Add support for ROC Gemini

### DIFF
--- a/GameData/KerbalismConfig/Support/ROCapsules.cfg
+++ b/GameData/KerbalismConfig/Support/ROCapsules.cfg
@@ -60,6 +60,50 @@
         }
     }
 }
+@PART[ROC-GeminiCM]:NEEDS[RealFuels,ROCapsules]:AFTER[ROCapsules]
+{
+    @description ^= :$: Supports a crew of two for up to maximum 14 days of active operations but it will require fuel cells.
+
+    @MODULE[ModuleFuelTanks]
+    {
+        TANK
+		{
+			name = Food
+			amount = 164
+			maxAmount = 164	// 14 days
+		}
+		TANK
+		{
+			name = Water
+			amount = 8
+			maxAmount = 8	// 1 day
+		}
+		TANK
+		{
+			name = Oxygen
+			amount = 1184
+			maxAmount = 1184	// 1 day
+		}
+		TANK
+		{
+			name = Waste
+			amount = 0
+			maxAmount = 111	// 14 days
+		}
+		TANK
+		{
+			name = WasteWater
+			amount = 0
+			maxAmount = 138	// 14 days
+		}
+		TANK
+		{
+			name = LithiumHydroxide
+			amount = 29
+			maxAmount = 29	// 14 days
+		}
+    }
+}
 
 @PART[ROC-ApolloCM]:NEEDS[RealFuels,ROCapsules]:AFTER[ROCapsules]
 {

--- a/GameData/KerbalismConfig/System/Habitat.cfg
+++ b/GameData/KerbalismConfig/System/Habitat.cfg
@@ -107,7 +107,7 @@
 		%max_pressure = 0.35
 	}
 }
-@PART[FASAGeminiPod2,FASAGeminiPod2White,ROAdvCapsule]:NEEDS[FeatureHabitat]:AFTER[Kerbalism]
+@PART[FASAGeminiPod2,FASAGeminiPod2White,ROAdvCapsule,ROC-GeminiCM]:NEEDS[FeatureHabitat]:AFTER[Kerbalism]
 {
 	@MODULE[Habitat]
 	{

--- a/GameData/KerbalismConfig/System/Parts.cfg
+++ b/GameData/KerbalismConfig/System/Parts.cfg
@@ -468,7 +468,7 @@
     }
   }
 }
-//Apollo SM
+//Gemini SM
 @PART[ROC-GeminiEquipmentSection|FASAGeminiUtilityPack|ROAdvCapsule]:NEEDS[ProfileRealismOverhaul]:AFTER[RealismOverhaul]
 {
   MODULE

--- a/GameData/KerbalismConfig/System/Parts.cfg
+++ b/GameData/KerbalismConfig/System/Parts.cfg
@@ -304,7 +304,7 @@
 }
 
 //Gemini
-@PART[Mk2Pod|FASAGeminiPod2|FASAGeminiPod2White|ROAdvCapsule]:NEEDS[ProfileRealismOverhaul]:AFTER[RealismOverhaul]
+@PART[Mk2Pod|FASAGeminiPod2|FASAGeminiPod2White|ROAdvCapsule|ROC-GeminiCM]:NEEDS[ProfileRealismOverhaul]:AFTER[RealismOverhaul]
 {
   MODULE
   {
@@ -466,6 +466,35 @@
         id_value = _NonRegenScrubber
       }
     }
+  }
+}
+//Apollo SM
+@PART[ROC-GeminiEquipmentSection|FASAGeminiUtilityPack|ROAdvCapsule]:NEEDS[ProfileRealismOverhaul]:AFTER[RealismOverhaul]
+{
+  MODULE
+  {
+    name = ProcessController
+    resource = _FuelCell
+    title = Fuel Cell 1 
+    capacity = 2.2
+	toggle = true
+    running = true
+  }
+   MODULE
+  {
+    name = ProcessController
+    resource = _FuelCell
+    title = Fuel Cell 2
+    capacity = 2.2
+	toggle = true
+    running = true
+  }
+   MODULE
+  {
+	name = ProcessController
+	resource = _LOXConverter
+	title = LOX to GOX Converter
+	capacity = 1
   }
 }
 


### PR DESCRIPTION
Add support for ROC-Gemini, and other Geminis. The FASA gemini has had Fuel Cells and a LOX to GOX converter add to its equipment section. The RO Advanced Capsule has also had fuel cells and LOX-GOX converters add because it has its service module built in.

ROC PR: https://github.com/KSP-RO/ROCapsules/pull/16