### PR TITLE
Better habitat config for PPD-4/6

### DIFF
--- a/GameData/KerbalismConfig/System/Habitat.cfg
+++ b/GameData/KerbalismConfig/System/Habitat.cfg
@@ -180,6 +180,22 @@
 	}
 }
 
+@PART[SXTCrewCabSSP10]:NEEDS[FeatureHabitat]:AFTER[Kerbalism]
+{
+	@MODULE[Habitat]
+	{
+		// %max_pressure = 0.35 // arbitrary: if gemini gets 0.35, an Early Station part should too
+		%volume = 4.5 // also arbitrary: about double gemini, substantially less than total part volume
+	}
+}
+@PART[SXTCrewCabSSP20]:NEEDS[FeatureHabitat]:AFTER[Kerbalism]
+{
+	@MODULE[Habitat]
+	{
+		%max_pressure = 0.35 // same as SSP10
+		%volume = 9 // double SSP10 for double the crew. (part volume is less than double, but that makes sense)
+	}
+}
 // ============================================================================
 // Unpressurized tag
 // ============================================================================

--- a/GameData/KerbalismConfig/System/Parts.cfg
+++ b/GameData/KerbalismConfig/System/Parts.cfg
@@ -1160,11 +1160,6 @@ MODULE
     @capacity *= 1.5
   }
   
-  @MODULE[Habitat]
-  {
-	max_pressure = 0.3
-  }
-  
   MODULE
   {
     name = Configure


### PR DESCRIPTION
- bump up max_pressure to same level as Gemini. This multiplies
  time-to-100%-stress by ~10x (!)
- explicitly set a volume, to roughly half the total part volume
  (cutting time-to-100%-stress by ~50%)

Main intent is to make Early Space Station parts usable for the
First Space Station rp-1 contract: 30d with at least 2 crew, room for 3.

Without this, a PPD-6 (4 seats) only lasted ~20d with 2 crew.
With this change, that becomes ~100d; probably too much, but a better
starting point. (standecco floated the idea of cutting the pressure bonus in half; 50d wouldn't be bad)