### PR TITLE
Add RN Soyuz orbital modules to Crew Science

### DIFF
--- a/GameData/KerbalismConfig/System/Science/CrewScience/Experiments/MatureCapsuleExperiments.cfg
+++ b/GameData/KerbalismConfig/System/Science/CrewScience/Experiments/MatureCapsuleExperiments.cfg
@@ -1,7 +1,7 @@
 // ============================================================================
 // Add tag to parts
 // ============================================================================
-@PART[FASAGeminiBigG|FASAGeminiBigGWhite|SSTU-SC-A-OM|bluedog_Apollo_Block2_Capsule|FASAApollo_CM|SSTU-SC-B-CM|Mark1-2Pod|mk1-3pod|rn_lok_bo|t_af_bo|SSTU-SC-B-CMX|rn_astp_bo|bluedog_Apollo_Block3_Capsule|MK2VApod|rn_va_capsule|SOYUZ_orbitalSegment|mk3-9pod|SSTU-SC-C-CM|SSTU-SC-C-CMX|XOrionPodXbb31|XOrionPodX|inlineCmdPod|CST-100?capsule|MK1CrewCabin|mk2Cockpit_Standard|mk2Cockpit_Inline|mk2CrewCabin|mk3Cockpit_Shuttle]:NEEDS[FeatureScience]:BEFORE[RP-0-Kerbalism]
+@PART[FASAGeminiBigG|FASAGeminiBigGWhite|SSTU-SC-A-OM|bluedog_Apollo_Block2_Capsule|FASAApollo_CM|SSTU-SC-B-CM|Mark1-2Pod|mk1-3pod|rn_lok_bo|t_bo|t_af_bo|SSTU-SC-B-CMX|rn_astp_bo|bluedog_Apollo_Block3_Capsule|MK2VApod|rn_va_capsule|SOYUZ_orbitalSegment|mk3-9pod|SSTU-SC-C-CM|SSTU-SC-C-CMX|XOrionPodXbb31|XOrionPodX|inlineCmdPod|CST-100?capsule|MK1CrewCabin|mk2Cockpit_Standard|mk2Cockpit_Inline|mk2CrewCabin|mk3Cockpit_Shuttle]:NEEDS[FeatureScience]:BEFORE[RP-0-Kerbalism]
 {
 	%capsuleTier = Mature
 }

--- a/GameData/KerbalismConfig/System/Science/CrewScience/Experiments/SecondGenExperiments.cfg
+++ b/GameData/KerbalismConfig/System/Science/CrewScience/Experiments/SecondGenExperiments.cfg
@@ -1,7 +1,7 @@
 // ============================================================================
 // Add tag to parts
 // ============================================================================
-@PART[Mk2Pod|kv3Pod|FASAGeminiPod2|FASAGeminiPod2White|K2Pod|ROAdvCapsule|Voskhod_Crew_A|RO-Mk1CrewModule|RO-Mk1CockpitInline|RO-Mk1Cockpit]:NEEDS[FeatureScience]:BEFORE[RP-0-Kerbalism]
+@PART[Mk2Pod|kv3Pod|FASAGeminiPod2|FASAGeminiPod2White|K2Pod|ROAdvCapsule|Voskhod_Crew_A|RO-Mk1CrewModule|RO-Mk1CockpitInline|RO-Mk1Cockpit|ok_bo_male|ok_bo_fem]:NEEDS[FeatureScience]:BEFORE[RP-0-Kerbalism]
 {
     %capsuleTier = SecondGen
 }


### PR DESCRIPTION
Crew Science was missing for several Soyuz Orbital Modules from the RN Soyuz mod