### PR TITLE
Various life support FIXME's

### DIFF
--- a/GameData/KerbalismConfig/Profiles/ROKerbalism.cfg
+++ b/GameData/KerbalismConfig/Profiles/ROKerbalism.cfg
@@ -254,7 +254,7 @@ Supply
 		modifier = _VacScrubber
 		input = ElectricCharge@0.15
 		input = WasteAtmosphere@0.006216
-		output = CarbonDioxide@0.00003932
+		output = CarbonDioxide@0.0.0055944 //90% efficiency, roughly 100g per day lost to space
 		dump = true
 	}
 

--- a/GameData/KerbalismConfig/Profiles/ROKerbalism.cfg
+++ b/GameData/KerbalismConfig/Profiles/ROKerbalism.cfg
@@ -10,8 +10,8 @@
 // NTRS - Radiation Protection for Lunar Mission Scenarios (2005): https://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/20050215115.pdf
 // NHRP - Risk of Radiation Carcinogenesis(2009) : https://humanresearchroadmap.nasa.gov/evidence/reports/Carcinogenesis.pdf
 // NTRS - Physical Basis of Radiation Protection in Space Travel, Cucinotta : https://www.academia.edu/29473649/Physical_basis_of_radiation_protection_in_space_travel
+// NTRS - Would Current ISS Recycling Life Support Systems Save Mass on a Mars Transit? (2017) : https://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/20170007268.pdf
 
-    
 	// Carbon Dioxide Toxicity
 	// 1% in air = Drowsiness
 	// 3% in air = Mild narcosis, Reduced Hearing, Increased Heart Rate and Blood Pressure
@@ -103,7 +103,7 @@ Supply
 // ==============================================================================
 // RULES
 // ==============================================================================
-    
+
 	Rule
 	{
 		name = climatization
@@ -136,7 +136,7 @@ Supply
 		input = Water
 		output = WasteWater
 		rate = 0.774144 // Based on RO-TACLS Profile (3.87072 per day)
-		interval = 17280.0 // 5 drinks per-day 
+		interval = 17280.0 // 5 drinks per-day
 		degeneration = 0.0666666 // 15 drinks, 3 days (taken from TACLS profile)
 		individuality = 0.00 // Everyone uses the same amount
 		warning_message = $ON_VESSEL$KERBAL is thirsty
@@ -211,7 +211,7 @@ Supply
 		input = WasteAtmosphere@0.0099  			// efficiency starts at 2 (2 x a pods scrubber), reaches 1 in 8h, then drops below
 		input = _EVAScrubber@0.0000347
 	}
-	
+
 	//Made for the Mercury Capsule
 	Process
 	{
@@ -224,7 +224,7 @@ Supply
 		output = Waste@0.00003234					//Li2CO3 accumulating in the filters for mass conservation
 		dump = true
 	}
-  
+
 	// Water sublimator for heat removal, currently half-useless since kerbals won't die when it runs out
 	// Used to add EC consumption and water tanks to EVA - based on the Apollo PLSS
 	Process
@@ -257,7 +257,7 @@ Supply
 		output = CarbonDioxide@0.00003932
 		dump = true
 	}
-	
+
 	//Based on the Orion vacuum scrubber
 	// convention: 1 capacity = enough to scrub output of 1 crew member
 	Process
@@ -269,7 +269,7 @@ Supply
 		output = CarbonDioxide@0.00003932
 		dump = true
 	}
-	
+
 	// Vostok/Voskhod used KO2 to generate O2 (4KO2 + 2H2O -> 4KOH + 3O2) and absorb CO2 (4KOH + 2CO2 -> 2K2CO3 + H2O)
 	// 284.4g of Potassium Superoxide and 36g of Water give 96g of Oxygen and 224.4g of KOH (in this case, Waste)
 	// for 835g of O2 (1 human daily consumption), 2472.2g of KO2 and 313g of H2O are needed
@@ -328,10 +328,10 @@ Supply
 		input = ElectricCharge@0.1
 		input = WasteWater@0.00000619
 		output = Water@0.0000336 // ISS currently achieves 75% Water recovery
-		output = Ammonia@0.00000104 // Based on Wikipedia, we assume 4.21% of WasteWater is solids and 55% of solids are Urea    
+		output = Ammonia@0.00000104 // Based on Wikipedia, we assume 4.21% of WasteWater is solids and 55% of solids are Urea
 		dump_valve = Water,Ammonia,Water&Ammonia
 	}
-  
+
 	// FIXME: These don't exist yet, but most likely unnecessary in orbit as it is dumped from the craft. What to do on land bases? Add this for Moon Bases / Mars Bases?
 	// convention: 1 capacity = enough to process output of 1 crew member
 	Process
@@ -345,7 +345,7 @@ Supply
 			// Feces is considered to the dominant source of Waste
 			// Waste is 975.3 times more dense than Ammonia
 	}
-	
+
 	Process
 	{
 		name = waste incinerator
@@ -357,7 +357,7 @@ Supply
 		output = ElectricCharge@0.005
 		dump_valve = Water,ElectricCharge,Water&ElectricCharge
 	}
-  
+
 	Process
 	{
 		name = atmo leaks
@@ -369,7 +369,7 @@ Supply
 			// average module radius and corresponding surface area: 1.552 m, 1220 m² (estimated)
 			// leak rate 0.0004 kg/(day*m²)
 	}
-	
+
 	// Fuel Cells are based off of 1.0kW produced. For the process controller, we
 	// should be multiplying the capacity * the amount we want produced
 	// Eg. Apollo Fuel Cells were 1.42kW so the capacity = 1.42
@@ -383,7 +383,7 @@ Supply
 		output = ElectricCharge@1.0
 		dump_valve = Water
 	}
-  
+
 	// Based on current electrolysis rates where it takes 12.749kWh to make 1L of H
 	// Convention: 1 "unit" creates just a little more O2 per second than is needed for 1 crew
 	Process
@@ -396,7 +396,7 @@ Supply
 		output = Oxygen@0.007
 		dump_valve = Hydrogen,Oxygen
 	}
-  
+
 	Process
 	{
 		name = sabatier process
@@ -441,11 +441,11 @@ Supply
 		name = ox to lox converter
 		modifier = _OXConverter
 		input = Oxygen@0.0125104279
-		input = ElectricCharge@0.007381
+		input = ElectricCharge@0.08291478 // Best option 2873 W for 2.2kg/hr source: https://www.sciencedirect.com/science/article/pii/S0011227517302187
 		output = LqdOxygen@0.0000154599
 	}
 
-	// convention: 1 capacity = enough to liquify the output of 1 electrolizer 
+	// convention: 1 capacity = enough to liquify the output of 1 electrolizer
 	Process
 	{
 		name = lh2 to h2 converter
@@ -460,7 +460,7 @@ Supply
 		name = h2 to lh2 converter
 		modifier = _H2Converter
 		input = Hydrogen@11.1121802
-		input = ElectricCharge@2.88	// 66% efficiency 
+		input = ElectricCharge@2.88	// 66% efficiency
 		output = LqdHydrogen@0.0141
 	}
 
@@ -486,14 +486,14 @@ Supply
   // This is caused by thermocoupler degradation. More advanced thermocuplers could generate
   // 25% more power at the beginning of a mission and at least 50% more after seventeen years.
   // source: https://www.jpl.nasa.gov/news/news.php?feature=6646
-  Process 
+  Process
   {
     name = RTG
     modifier = _RTG
     input = _RTG@0.00000000039637  // 40 year half-life
     output = ElectricCharge@1.0
 	dump = true
-  } 
+  }
 }
 
 // ============================================================================
@@ -610,13 +610,13 @@ Supply
 				slots = 3
 			}
     	}
-	
+
 		SETUP
 		{
 			name = None
 			desc = Empty slot for mass and cost savings.
 		}
-		
+
 		SETUP
 		{
 			name = LiOHScrubber
@@ -632,7 +632,7 @@ Supply
 				id_value = _Scrubber
 			}
 		}
-		
+
 		SETUP
 		{
 			name = KO2 Scrubber
@@ -664,13 +664,13 @@ Supply
 				id_value = _VacScrubber
 			}
 		}
-		
+
 		SETUP
 		{
 			name = Advanced Vacuum Scrubber
 			desc = An advanced dual-bed vacuum-exposing regenerative scrubber that sequesters <b>CarbonDioxide</b> from the internal atmosphere.
 			tech = improvedLifeSupport
-			mass = 0.02 //FIXME
+			mass = 0.05 //Current ISS CDRA system is 197kg for 4 crew.
 			cost = 20 //FIXME
 
 			MODULE
@@ -734,7 +734,7 @@ Supply
 			name = Water Recycler
 			desc = Filter impurities out of <b>WasteWater</b>.
 			tech = advancedLifeSupport
-			mass = 0.05 //FIXME
+			mass = 0.19 //  Using ISS urine processing system since that's our only wastewater generator, 742kg for 4 crew
 			cost = 50 //FIXME
 
 			MODULE
@@ -808,7 +808,7 @@ Supply
 	name = Configure
 	title = Fuel Cell
 	slots = 1
-	
+
 	SETUP //Gemini
 	{
 		name = Acid IEM Fuel Cell
@@ -823,14 +823,14 @@ Supply
         id_value = Gemini Fuel Cell
       }
 	}
-	
+
 	SETUP //Apollo
     {
       name = Apollo alkaline Fuel Cell
       desc = Combines <b>LqdHydrogen</b> and <b>LqdOxygen</b> to produce <b>Water</b> and <b>Electricity</b>.
       tech = lunarRatedPower
       mass = 0.075
-	  
+
       MODULE
       {
         type = ProcessController
@@ -838,7 +838,7 @@ Supply
         id_value = Apollo Fuel Cell
       }
 	}
-	
+
 	SETUP //Shuttle
     {
       name = Shuttle alkaline Fuel Cell
@@ -894,7 +894,7 @@ Supply
 	name = Configure
 	title = Fuel Cell
 	slots = 1
-	
+
 	SETUP //Gemini
 	{
 		name = Acid IEM Fuel Cell
@@ -909,14 +909,14 @@ Supply
         id_value = Gemini Fuel Cell
       }
 	}
-	
+
 	SETUP //Apollo
     {
       name = Apollo alkaline Fuel Cell
       desc = Combines <b>LqdHydrogen</b> and <b>LqdOxygen</b> to produce <b>Water</b> and <b>Electricity</b>.
       tech = lunarRatedPower
       mass = 0.05625
-	  
+
       MODULE
       {
         type = ProcessController
@@ -924,7 +924,7 @@ Supply
         id_value = Apollo Fuel Cell
       }
 	}
-	
+
 	SETUP //Shuttle
     {
       name = Shuttle alkaline Fuel Cell
@@ -980,7 +980,7 @@ Supply
 	name = Configure
 	title = Fuel Cell
 	slots = 1
-	
+
 	SETUP //Gemini
 	{
 		name = Acid IEM Fuel Cell
@@ -995,14 +995,14 @@ Supply
         id_value = Gemini Fuel Cell
       }
 	}
-	
+
 	SETUP //Apollo
     {
       name = Apollo alkaline Fuel Cell
       desc = Combines <b>LqdHydrogen</b> and <b>LqdOxygen</b> to produce <b>Water</b> and <b>Electricity</b>.
       tech = lunarRatedPower
       mass = 0.4125
-	  
+
       MODULE
       {
         type = ProcessController
@@ -1010,7 +1010,7 @@ Supply
         id_value = Apollo Fuel Cell
       }
 	}
-	
+
 	SETUP //Shuttle
     {
       name = Shuttle alkaline Fuel Cell
@@ -1121,7 +1121,7 @@ Supply
         slots = 0
       }
     }
-		
+
 	SETUP
 	{
 		name = None
@@ -1133,7 +1133,7 @@ Supply
       name = Water Electrolysis
       desc = Split <b>Water</b> into its <b>Hydrogen</b> and <b>Oxygen</b> components.
 	  tech = longTermLifeSupport
-	  mass = 0.05 //FIXME
+	  mass = 0.17 // ISS OGS is 676 kgs for 4 crew
       cost = 50 //FIXME
 
       MODULE
@@ -1149,7 +1149,7 @@ Supply
       name = Sabatier Process
       desc = <b>LqdHydrogen</b> and <b>CarbonDioxide</b> react with a nickel catalyst to produce <b>Water</b> and <b>LqdMethane</b>.
 	  tech = advancedLifeSupport
-	  mass = 0.05 //FIXME
+	  mass = 0.08 //  ISS CRS is 329 kgs for 4 crew
       cost = 50 //FIXME
 
       MODULE
@@ -1159,7 +1159,7 @@ Supply
         id_value = _Sabatier
       }
     }
-	
+
 	SETUP
     {
       name = Waste Incinerator
@@ -1195,7 +1195,7 @@ Supply
       name = GOX to LOX Converter
       desc = Liquifies breathable <b>Oxygen</b> into <b>LqdOxygen</b>.
 	  tech = lifeSupportISRU
-	  mass = 0.2 //FIXME
+	  mass = 0.001 //FIXME  Best option processes 2.2kg/hr w/mass of 68kg source: https://www.sciencedirect.com/science/article/pii/S0011227517302187
       cost = 50 //FIXME
 
       MODULE
@@ -1287,7 +1287,7 @@ Supply
 // ============================================================================
 
 @PART:HAS[@MODULE[LaunchClamp]|@MODULE[ModuleRestockLaunchClamp]]:NEEDS[ProfileRealismOverhaul]:FOR[zzzKerbalism]
-{	
+{
 	MODULE
 	{
 		name = ProcessController

--- a/GameData/KerbalismConfig/Profiles/ROKerbalism.cfg
+++ b/GameData/KerbalismConfig/Profiles/ROKerbalism.cfg
@@ -654,7 +654,7 @@ Supply
 			name = Vacuum Scrubber
 			desc = A dual-bed vacuum-exposing regenerative scrubber that sequesters <b>CarbonDioxide</b> from the internal atmosphere.
 			tech = basicLifeSupport
-			mass = 0.03 //FIXME
+			mass = 0.15 //FIXME
 			cost = 25 //FIXME
 
 			MODULE

--- a/GameData/KerbalismConfig/Profiles/ROKerbalism.cfg
+++ b/GameData/KerbalismConfig/Profiles/ROKerbalism.cfg
@@ -440,9 +440,9 @@ Supply
 	{
 		name = ox to lox converter
 		modifier = _OXConverter
-		input = Oxygen@0.0125104279
-		input = ElectricCharge@0.08291478 // Best option 2873 W for 2.2kg/hr source: https://www.sciencedirect.com/science/article/pii/S0011227517302187
-		output = LqdOxygen@0.0000154599
+		input = Oxygen@0.125104279
+		input = ElectricCharge@0.8291478 // Best option 2873 W for 2.2kg/hr source: https://www.sciencedirect.com/science/article/pii/S0011227517302187
+		output = LqdOxygen@0.000154599
 	}
 
 	// convention: 1 capacity = enough to liquify the output of 1 electrolizer
@@ -670,7 +670,7 @@ Supply
 			name = Advanced Vacuum Scrubber
 			desc = An advanced dual-bed vacuum-exposing regenerative scrubber that sequesters <b>CarbonDioxide</b> from the internal atmosphere.
 			tech = improvedLifeSupport
-			mass = 0.05 //Current ISS CDRA system is 197kg for 4 crew.
+			mass = 0.15 //Current ISS CDRA system is 197kg for 4 crew.
 			cost = 20 //FIXME
 
 			MODULE
@@ -734,7 +734,7 @@ Supply
 			name = Water Recycler
 			desc = Filter impurities out of <b>WasteWater</b>.
 			tech = advancedLifeSupport
-			mass = 0.19 //  Using ISS urine processing system since that's our only wastewater generator, 742kg for 4 crew
+			mass = 0.57 //  Using ISS urine processing system since that's our only wastewater generator, 742kg for 4 crew
 			cost = 50 //FIXME
 
 			MODULE
@@ -1195,7 +1195,7 @@ Supply
       name = GOX to LOX Converter
       desc = Liquifies breathable <b>Oxygen</b> into <b>LqdOxygen</b>.
 	  tech = lifeSupportISRU
-	  mass = 0.001 //FIXME  Best option processes 2.2kg/hr w/mass of 68kg source: https://www.sciencedirect.com/science/article/pii/S0011227517302187
+	  mass = 0.01 //FIXME  Best option processes 2.2kg/hr w/mass of 68kg source: https://www.sciencedirect.com/science/article/pii/S0011227517302187
       cost = 50 //FIXME
 
       MODULE

--- a/GameData/KerbalismConfig/Profiles/ROKerbalism.cfg
+++ b/GameData/KerbalismConfig/Profiles/ROKerbalism.cfg
@@ -10,8 +10,8 @@
 // NTRS - Radiation Protection for Lunar Mission Scenarios (2005): https://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/20050215115.pdf
 // NHRP - Risk of Radiation Carcinogenesis(2009) : https://humanresearchroadmap.nasa.gov/evidence/reports/Carcinogenesis.pdf
 // NTRS - Physical Basis of Radiation Protection in Space Travel, Cucinotta : https://www.academia.edu/29473649/Physical_basis_of_radiation_protection_in_space_travel
-// NTRS - Would Current ISS Recycling Life Support Systems Save Mass on a Mars Transit? (2017) : https://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/20170007268.pdf
 
+    
 	// Carbon Dioxide Toxicity
 	// 1% in air = Drowsiness
 	// 3% in air = Mild narcosis, Reduced Hearing, Increased Heart Rate and Blood Pressure
@@ -103,7 +103,7 @@ Supply
 // ==============================================================================
 // RULES
 // ==============================================================================
-
+    
 	Rule
 	{
 		name = climatization
@@ -136,7 +136,7 @@ Supply
 		input = Water
 		output = WasteWater
 		rate = 0.774144 // Based on RO-TACLS Profile (3.87072 per day)
-		interval = 17280.0 // 5 drinks per-day
+		interval = 17280.0 // 5 drinks per-day 
 		degeneration = 0.0666666 // 15 drinks, 3 days (taken from TACLS profile)
 		individuality = 0.00 // Everyone uses the same amount
 		warning_message = $ON_VESSEL$KERBAL is thirsty
@@ -211,7 +211,7 @@ Supply
 		input = WasteAtmosphere@0.0099  			// efficiency starts at 2 (2 x a pods scrubber), reaches 1 in 8h, then drops below
 		input = _EVAScrubber@0.0000347
 	}
-
+	
 	//Made for the Mercury Capsule
 	Process
 	{
@@ -224,7 +224,7 @@ Supply
 		output = Waste@0.00003234					//Li2CO3 accumulating in the filters for mass conservation
 		dump = true
 	}
-
+  
 	// Water sublimator for heat removal, currently half-useless since kerbals won't die when it runs out
 	// Used to add EC consumption and water tanks to EVA - based on the Apollo PLSS
 	Process
@@ -257,7 +257,7 @@ Supply
 		output = CarbonDioxide@0.00003932
 		dump = true
 	}
-
+	
 	//Based on the Orion vacuum scrubber
 	// convention: 1 capacity = enough to scrub output of 1 crew member
 	Process
@@ -269,7 +269,7 @@ Supply
 		output = CarbonDioxide@0.00003932
 		dump = true
 	}
-
+	
 	// Vostok/Voskhod used KO2 to generate O2 (4KO2 + 2H2O -> 4KOH + 3O2) and absorb CO2 (4KOH + 2CO2 -> 2K2CO3 + H2O)
 	// 284.4g of Potassium Superoxide and 36g of Water give 96g of Oxygen and 224.4g of KOH (in this case, Waste)
 	// for 835g of O2 (1 human daily consumption), 2472.2g of KO2 and 313g of H2O are needed
@@ -328,10 +328,10 @@ Supply
 		input = ElectricCharge@0.1
 		input = WasteWater@0.00000619
 		output = Water@0.0000336 // ISS currently achieves 75% Water recovery
-		output = Ammonia@0.00000104 // Based on Wikipedia, we assume 4.21% of WasteWater is solids and 55% of solids are Urea
+		output = Ammonia@0.00000104 // Based on Wikipedia, we assume 4.21% of WasteWater is solids and 55% of solids are Urea    
 		dump_valve = Water,Ammonia,Water&Ammonia
 	}
-
+  
 	// FIXME: These don't exist yet, but most likely unnecessary in orbit as it is dumped from the craft. What to do on land bases? Add this for Moon Bases / Mars Bases?
 	// convention: 1 capacity = enough to process output of 1 crew member
 	Process
@@ -345,7 +345,7 @@ Supply
 			// Feces is considered to the dominant source of Waste
 			// Waste is 975.3 times more dense than Ammonia
 	}
-
+	
 	Process
 	{
 		name = waste incinerator
@@ -357,7 +357,7 @@ Supply
 		output = ElectricCharge@0.005
 		dump_valve = Water,ElectricCharge,Water&ElectricCharge
 	}
-
+  
 	Process
 	{
 		name = atmo leaks
@@ -369,7 +369,7 @@ Supply
 			// average module radius and corresponding surface area: 1.552 m, 1220 m² (estimated)
 			// leak rate 0.0004 kg/(day*m²)
 	}
-
+	
 	// Fuel Cells are based off of 1.0kW produced. For the process controller, we
 	// should be multiplying the capacity * the amount we want produced
 	// Eg. Apollo Fuel Cells were 1.42kW so the capacity = 1.42
@@ -383,7 +383,7 @@ Supply
 		output = ElectricCharge@1.0
 		dump_valve = Water
 	}
-
+  
 	// Based on current electrolysis rates where it takes 12.749kWh to make 1L of H
 	// Convention: 1 "unit" creates just a little more O2 per second than is needed for 1 crew
 	Process
@@ -396,7 +396,7 @@ Supply
 		output = Oxygen@0.007
 		dump_valve = Hydrogen,Oxygen
 	}
-
+  
 	Process
 	{
 		name = sabatier process
@@ -441,11 +441,11 @@ Supply
 		name = ox to lox converter
 		modifier = _OXConverter
 		input = Oxygen@0.0125104279
-		input = ElectricCharge@0.08291478 // Best option 2873 W for 2.2kg/hr source: https://www.sciencedirect.com/science/article/pii/S0011227517302187
+		input = ElectricCharge@0.007381
 		output = LqdOxygen@0.0000154599
 	}
 
-	// convention: 1 capacity = enough to liquify the output of 1 electrolizer
+	// convention: 1 capacity = enough to liquify the output of 1 electrolizer 
 	Process
 	{
 		name = lh2 to h2 converter
@@ -460,7 +460,7 @@ Supply
 		name = h2 to lh2 converter
 		modifier = _H2Converter
 		input = Hydrogen@11.1121802
-		input = ElectricCharge@2.88	// 66% efficiency
+		input = ElectricCharge@2.88	// 66% efficiency 
 		output = LqdHydrogen@0.0141
 	}
 
@@ -486,14 +486,14 @@ Supply
   // This is caused by thermocoupler degradation. More advanced thermocuplers could generate
   // 25% more power at the beginning of a mission and at least 50% more after seventeen years.
   // source: https://www.jpl.nasa.gov/news/news.php?feature=6646
-  Process
+  Process 
   {
     name = RTG
     modifier = _RTG
     input = _RTG@0.00000000039637  // 40 year half-life
     output = ElectricCharge@1.0
 	dump = true
-  }
+  } 
 }
 
 // ============================================================================
@@ -610,13 +610,13 @@ Supply
 				slots = 3
 			}
     	}
-
+	
 		SETUP
 		{
 			name = None
 			desc = Empty slot for mass and cost savings.
 		}
-
+		
 		SETUP
 		{
 			name = LiOHScrubber
@@ -632,7 +632,7 @@ Supply
 				id_value = _Scrubber
 			}
 		}
-
+		
 		SETUP
 		{
 			name = KO2 Scrubber
@@ -664,13 +664,13 @@ Supply
 				id_value = _VacScrubber
 			}
 		}
-
+		
 		SETUP
 		{
 			name = Advanced Vacuum Scrubber
 			desc = An advanced dual-bed vacuum-exposing regenerative scrubber that sequesters <b>CarbonDioxide</b> from the internal atmosphere.
 			tech = improvedLifeSupport
-			mass = 0.05 //Current ISS CDRA system is 197kg for 4 crew.
+			mass = 0.02 //FIXME
 			cost = 20 //FIXME
 
 			MODULE
@@ -734,7 +734,7 @@ Supply
 			name = Water Recycler
 			desc = Filter impurities out of <b>WasteWater</b>.
 			tech = advancedLifeSupport
-			mass = 0.19 //  Using ISS urine processing system since that's our only wastewater generator, 742kg for 4 crew
+			mass = 0.05 //FIXME
 			cost = 50 //FIXME
 
 			MODULE
@@ -808,7 +808,7 @@ Supply
 	name = Configure
 	title = Fuel Cell
 	slots = 1
-
+	
 	SETUP //Gemini
 	{
 		name = Acid IEM Fuel Cell
@@ -823,14 +823,14 @@ Supply
         id_value = Gemini Fuel Cell
       }
 	}
-
+	
 	SETUP //Apollo
     {
       name = Apollo alkaline Fuel Cell
       desc = Combines <b>LqdHydrogen</b> and <b>LqdOxygen</b> to produce <b>Water</b> and <b>Electricity</b>.
       tech = lunarRatedPower
       mass = 0.075
-
+	  
       MODULE
       {
         type = ProcessController
@@ -838,7 +838,7 @@ Supply
         id_value = Apollo Fuel Cell
       }
 	}
-
+	
 	SETUP //Shuttle
     {
       name = Shuttle alkaline Fuel Cell
@@ -894,7 +894,7 @@ Supply
 	name = Configure
 	title = Fuel Cell
 	slots = 1
-
+	
 	SETUP //Gemini
 	{
 		name = Acid IEM Fuel Cell
@@ -909,14 +909,14 @@ Supply
         id_value = Gemini Fuel Cell
       }
 	}
-
+	
 	SETUP //Apollo
     {
       name = Apollo alkaline Fuel Cell
       desc = Combines <b>LqdHydrogen</b> and <b>LqdOxygen</b> to produce <b>Water</b> and <b>Electricity</b>.
       tech = lunarRatedPower
       mass = 0.05625
-
+	  
       MODULE
       {
         type = ProcessController
@@ -924,7 +924,7 @@ Supply
         id_value = Apollo Fuel Cell
       }
 	}
-
+	
 	SETUP //Shuttle
     {
       name = Shuttle alkaline Fuel Cell
@@ -980,7 +980,7 @@ Supply
 	name = Configure
 	title = Fuel Cell
 	slots = 1
-
+	
 	SETUP //Gemini
 	{
 		name = Acid IEM Fuel Cell
@@ -995,14 +995,14 @@ Supply
         id_value = Gemini Fuel Cell
       }
 	}
-
+	
 	SETUP //Apollo
     {
       name = Apollo alkaline Fuel Cell
       desc = Combines <b>LqdHydrogen</b> and <b>LqdOxygen</b> to produce <b>Water</b> and <b>Electricity</b>.
       tech = lunarRatedPower
       mass = 0.4125
-
+	  
       MODULE
       {
         type = ProcessController
@@ -1010,7 +1010,7 @@ Supply
         id_value = Apollo Fuel Cell
       }
 	}
-
+	
 	SETUP //Shuttle
     {
       name = Shuttle alkaline Fuel Cell
@@ -1121,7 +1121,7 @@ Supply
         slots = 0
       }
     }
-
+		
 	SETUP
 	{
 		name = None
@@ -1133,7 +1133,7 @@ Supply
       name = Water Electrolysis
       desc = Split <b>Water</b> into its <b>Hydrogen</b> and <b>Oxygen</b> components.
 	  tech = longTermLifeSupport
-	  mass = 0.17 // ISS OGS is 676 kgs for 4 crew
+	  mass = 0.05 //FIXME
       cost = 50 //FIXME
 
       MODULE
@@ -1149,7 +1149,7 @@ Supply
       name = Sabatier Process
       desc = <b>LqdHydrogen</b> and <b>CarbonDioxide</b> react with a nickel catalyst to produce <b>Water</b> and <b>LqdMethane</b>.
 	  tech = advancedLifeSupport
-	  mass = 0.08 //  ISS CRS is 329 kgs for 4 crew
+	  mass = 0.05 //FIXME
       cost = 50 //FIXME
 
       MODULE
@@ -1159,7 +1159,7 @@ Supply
         id_value = _Sabatier
       }
     }
-
+	
 	SETUP
     {
       name = Waste Incinerator
@@ -1195,7 +1195,7 @@ Supply
       name = GOX to LOX Converter
       desc = Liquifies breathable <b>Oxygen</b> into <b>LqdOxygen</b>.
 	  tech = lifeSupportISRU
-	  mass = 0.001 //FIXME  Best option processes 2.2kg/hr w/mass of 68kg source: https://www.sciencedirect.com/science/article/pii/S0011227517302187
+	  mass = 0.2 //FIXME
       cost = 50 //FIXME
 
       MODULE
@@ -1287,7 +1287,7 @@ Supply
 // ============================================================================
 
 @PART:HAS[@MODULE[LaunchClamp]|@MODULE[ModuleRestockLaunchClamp]]:NEEDS[ProfileRealismOverhaul]:FOR[zzzKerbalism]
-{
+{	
 	MODULE
 	{
 		name = ProcessController

--- a/GameData/KerbalismConfig/Profiles/ROKerbalism.cfg
+++ b/GameData/KerbalismConfig/Profiles/ROKerbalism.cfg
@@ -326,7 +326,7 @@ Supply
 		name = water recycler
 		modifier = _WaterRecycler
 		input = ElectricCharge@0.1
-		input = WasteWater@0.00000619
+		input = WasteWater@0.00004458  // Matched to single crew output
 		output = Water@0.0000336 // ISS currently achieves 75% Water recovery
 		output = Ammonia@0.00000104 // Based on Wikipedia, we assume 4.21% of WasteWater is solids and 55% of solids are Urea
 		dump_valve = Water,Ammonia,Water&Ammonia

--- a/GameData/KerbalismConfig/Profiles/ROKerbalism.cfg
+++ b/GameData/KerbalismConfig/Profiles/ROKerbalism.cfg
@@ -1084,7 +1084,7 @@ Supply
 	name = ProcessController
 	resource = _OXConverter
 	title = GOX to LOX Converter
-	capacity = 10
+	capacity = 1
 	running = true
   }
 
@@ -1195,7 +1195,7 @@ Supply
       name = GOX to LOX Converter
       desc = Liquifies breathable <b>Oxygen</b> into <b>LqdOxygen</b>.
 	  tech = lifeSupportISRU
-	  mass = 0.01 //FIXME  Best option processes 2.2kg/hr w/mass of 68kg source: https://www.sciencedirect.com/science/article/pii/S0011227517302187
+	  mass = 0.017 //FIXME  Best option processes 2.2kg/hr w/mass of 68kg source: https://www.sciencedirect.com/science/article/pii/S0011227517302187
       cost = 50 //FIXME
 
       MODULE


### PR DESCRIPTION
Found a few new sources for life support parts on the ISS and extrapolated mass numbers from theirs.  All of the masses went up, some significantly. This may put them out of line with estimates for earlier tech counterparts but I haven't found more information on those to cross reference.
https://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/20170007268.pdf

Found a paper on proposed mars oxygen liquefaction options and updated OX to LOX converter to match those numbers.  Mass dropped and wattage increased, both significantly.
https://www.sciencedirect.com/science/article/pii/S0011227517302187