### PR TITLE
Better habitat stats for RO-Mk1CrewModule

### DIFF
--- a/GameData/KerbalismConfig/System/Habitat.cfg
+++ b/GameData/KerbalismConfig/System/Habitat.cfg
@@ -107,6 +107,17 @@
 		%max_pressure = 0.35
 	}
 }
+@PART[RO-Mk1CrewModule]:NEEDS[FeatureHabitat]:AFTER[zzzKerbalism]
+{
+	@MODULE[Habitat]
+	{
+		// ~3m x ~3m cylinder, 3 seats. Narrower than Apollo's widest,
+		// wider than its narrowest, taller, call it a wash
+		%volume = 5.9
+		%surface = 20
+		%max_pressure = 0.35
+	}
+}
 @PART[FASAGeminiPod2,FASAGeminiPod2White,ROAdvCapsule]:NEEDS[FeatureHabitat]:AFTER[zzzKerbalism]
 {
 	@MODULE[Habitat]


### PR DESCRIPTION
A bit arbitrary, but better than the defaults it was inheriting
from the 1.25m KerbCan