### PR TITLE
Re-fix restock launchclamps

### DIFF
--- a/GameData/KerbalismConfig/Profiles/ROKerbalism.cfg
+++ b/GameData/KerbalismConfig/Profiles/ROKerbalism.cfg
@@ -1287,7 +1287,7 @@ Supply
 // Add EC Generation to Launch Clamps
 // ============================================================================
 
-@PART:HAS[@MODULE[LaunchClamp]|@MODULE[ModuleRestockLaunchClamp]]:NEEDS[ProfileRealismOverhaul]:FOR[zzzKerbalism]
+@PART:HAS[@MODULE[LaunchClamp]]:NEEDS[ProfileRealismOverhaul]:FOR[zzzKerbalism]
 {
 	MODULE
 	{
@@ -1309,6 +1309,30 @@ Supply
 	}
 	!MODULE[ModuleGenerator] {}
 }
+
+@PART:HAS[@MODULE[ModuleRestockLaunchClamp]]:NEEDS[ProfileRealismOverhaul]:FOR[zzzKerbalism]
+{
+	MODULE
+	{
+		name = ProcessController
+		resource = _ClampPump
+		title = Resource Pump
+		capacity = 10.0
+		running = true
+		toggle = true
+	}
+	MODULE
+	{
+		name = ProcessController
+		resource = _AirPump
+		title = Air Pump
+		capacity = 5.0
+		running = true
+		toggle = true
+	}
+	!MODULE[ModuleGenerator] {}
+}
+
 
 
 


### PR DESCRIPTION
From the MM handbook:
Note that HAS blocks currently do not support the usage of OR or |.
Situations where a patch needs to apply to two seperate requirements
will require two seperate patches.