### PR TITLE
Phase 1 ISRU changes

### DIFF
--- a/GameData/KerbalismConfig/Parts/ISRU/kerbalism-ISRU.cfg
+++ b/GameData/KerbalismConfig/Parts/ISRU/kerbalism-ISRU.cfg
@@ -1,0 +1,37 @@
+PART
+{
+	name = kerbalism-ISRU
+	module = Part
+	author = Ballatik
+
+	title = ISRU
+	manufacturer = Rookies Inc.
+	description = An even larger version of the chemical plant, for housing base-scale ISRU processes.
+	category = Utility
+	subcategory = 0
+
+	MODEL
+	{
+		model = Squad/Parts/Resources/MiniISRU/MiniISRU
+		scale = 2,2,2
+	}
+
+	node_stack_top = 0.0, .9, 0.0, 0.0, 1.0, 0.0, 1
+	node_stack_bottom = 0.0, -.9, 0.0, 0.0, -1.0, 0.0, 1
+	attachRules = 1,0,1,1,0
+
+	bulkheadProfiles = size1
+	dragModelType = default
+	maximum_drag = 0.2
+	minimum_drag = 0.2
+	angularDrag = 2
+	crashTolerance = 7
+	breakingForce = 50
+	breakingTorque = 50
+	maxTemp = 2000
+
+	TechRequired = lifesupportNF
+	entryCost = 8000
+	cost = 2000
+	mass = 0.04
+}

--- a/GameData/KerbalismConfig/Parts/ISRU/kerbalism-ISRU.cfg
+++ b/GameData/KerbalismConfig/Parts/ISRU/kerbalism-ISRU.cfg
@@ -16,8 +16,8 @@ PART
 		scale = 2,2,2
 	}
 
-	node_stack_top = 0.0, .9, 0.0, 0.0, 1.0, 0.0, 1
-	node_stack_bottom = 0.0, -.9, 0.0, 0.0, -1.0, 0.0, 1
+	node_stack_top = 0.0, 1.8, 0.0, 0.0, 1.0, 0.0, 1
+	node_stack_bottom = 0.0, -1.8, 0.0, 0.0, -1.0, 0.0, 1
 	attachRules = 1,0,1,1,0
 
 	bulkheadProfiles = size1

--- a/GameData/KerbalismConfig/Parts/ISRU/kerbalism-ISRU.cfg
+++ b/GameData/KerbalismConfig/Parts/ISRU/kerbalism-ISRU.cfg
@@ -16,8 +16,8 @@ PART
 		scale = 2,2,2
 	}
 
-	node_stack_top = 0.0, 1.8, 0.0, 0.0, 1.0, 0.0, 1
-	node_stack_bottom = 0.0, -1.8, 0.0, 0.0, -1.0, 0.0, 1
+	node_stack_top = 0.0, 1.5, 0.0, 0.0, 1.0, 0.0, 1
+	node_stack_bottom = 0.0, -1.5, 0.0, 0.0, -1.0, 0.0, 1
 	attachRules = 1,0,1,1,0
 
 	bulkheadProfiles = size1
@@ -33,5 +33,5 @@ PART
 	TechRequired = lifesupportNF
 	entryCost = 8000
 	cost = 2000
-	mass = 0.5
+	mass = 0.8	// 5 times the capacity but 4 times the mass of the MiniISRU, assuming some scaling efficiency
 }

--- a/GameData/KerbalismConfig/Parts/ISRU/kerbalism-ISRU.cfg
+++ b/GameData/KerbalismConfig/Parts/ISRU/kerbalism-ISRU.cfg
@@ -33,5 +33,5 @@ PART
 	TechRequired = lifesupportNF
 	entryCost = 8000
 	cost = 2000
-	mass = 0.04
+	mass = 0.5
 }

--- a/GameData/KerbalismConfig/Parts/ISRU/kerbalism-miniISRU.cfg
+++ b/GameData/KerbalismConfig/Parts/ISRU/kerbalism-miniISRU.cfg
@@ -32,5 +32,5 @@ PART
 	TechRequired = advancedLifeSupport
 	entryCost = 8000
 	cost = 2000
-	mass = 0.04
+	mass = 0.25
 }

--- a/GameData/KerbalismConfig/Parts/ISRU/kerbalism-miniISRU.cfg
+++ b/GameData/KerbalismConfig/Parts/ISRU/kerbalism-miniISRU.cfg
@@ -15,8 +15,8 @@ PART
 		model = Squad/Parts/Resources/MiniISRU/MiniISRU
 	}
 
-	node_stack_top = 0.0, .9, 0.0, 0.0, 1.0, 0.0, 1
-	node_stack_bottom = 0.0, -.9, 0.0, 0.0, -1.0, 0.0, 1
+	node_stack_top = 0.0, 0.75, 0.0, 0.0, 1.0, 0.0, 1
+	node_stack_bottom = 0.0, -0.75, 0.0, 0.0, -1.0, 0.0, 1
 	attachRules = 1,0,1,1,0
 
 	bulkheadProfiles = size1
@@ -32,5 +32,5 @@ PART
 	TechRequired = advancedLifeSupport
 	entryCost = 8000
 	cost = 2000
-	mass = 0.25
+	mass = 0.2
 }

--- a/GameData/KerbalismConfig/Parts/ISRU/kerbalism-miniISRU.cfg
+++ b/GameData/KerbalismConfig/Parts/ISRU/kerbalism-miniISRU.cfg
@@ -1,0 +1,36 @@
+PART
+{
+	name = kerbalism-miniISRU
+	module = Part
+	author = Ballatik
+
+	title = Mini ISRU
+	manufacturer = Rookies Inc.
+	description = A larger version of the chemical plant, for housing ISRU processes.
+	category = Utility
+	subcategory = 0
+
+	MODEL
+	{
+		model = Squad/Parts/Resources/MiniISRU/MiniISRU
+	}
+
+	node_stack_top = 0.0, .9, 0.0, 0.0, 1.0, 0.0, 1
+	node_stack_bottom = 0.0, -.9, 0.0, 0.0, -1.0, 0.0, 1
+	attachRules = 1,0,1,1,0
+
+	bulkheadProfiles = size1
+	dragModelType = default
+	maximum_drag = 0.2
+	minimum_drag = 0.2
+	angularDrag = 2
+	crashTolerance = 7
+	breakingForce = 50
+	breakingTorque = 50
+	maxTemp = 2000
+
+	TechRequired = advancedLifeSupport
+	entryCost = 8000
+	cost = 2000
+	mass = 0.04
+}

--- a/GameData/KerbalismConfig/Parts/Liquifier/LiquefactionArray.cfg
+++ b/GameData/KerbalismConfig/Parts/Liquifier/LiquefactionArray.cfg
@@ -1,0 +1,34 @@
+PART
+{
+name = LiquefactionArray
+module = Part
+author = Ballatik
+
+	MODEL
+	{
+		model = Squad/Parts/Resources/FuelCell/FuelCellArray
+	}
+	rescaleFactor = 1
+	node_attach = 0, 0, 0, 1, 0, 0, 0
+
+	TechRequired = lifeSupportNF
+	entryCost = 8000
+	cost = 2000
+	category = Utility
+	subcategory = 0
+	title = Liquefaction Array
+	manufacturer = Lambda Aerospace
+	description = A large part for turning gaseous fuel or oxygen into liquid to be used.
+	attachRules = 0,1,0,0,0
+
+	// --- standard part parameters ---
+	mass = 0.1
+	dragModelType = default
+	maximum_drag = 0.2
+	minimum_drag = 0.2
+	angularDrag = 2
+	crashTolerance = 7
+	maxTemp = 2000
+	bulkheadProfiles = srf
+
+}

--- a/GameData/KerbalismConfig/Parts/Liquifier/Liquifier.cfg
+++ b/GameData/KerbalismConfig/Parts/Liquifier/Liquifier.cfg
@@ -1,0 +1,35 @@
+﻿PART
+{
+	name = Liquifier
+	module = Part
+	author = Ballatik
+
+	title = Liquifier
+	manufacturer = Lambda Aerospace
+	description = A small part for turning gaseous fuel or oxygen into liquid to be used.
+	category = Utility
+	subcategory = 0
+
+	MODEL
+	{
+		model = Squad/Parts/Resources/FuelCell/FuelCell
+	}
+	rescaleFactor = 1
+	node_attach = 0, 0, 0, 1, 0, 0, 0
+
+	TechRequired = advancedLifeSupport
+	entryCost = 8000
+	cost = 2000
+	attachRules = 0,1,0,0,0
+
+	// --- standard part parameters ---
+	mass = 0.05
+	dragModelType = default
+	maximum_drag = 0.2
+	minimum_drag = 0.2
+	angularDrag = 2
+	crashTolerance = 7
+	maxTemp = 2000
+	bulkheadProfiles = srf
+
+}

--- a/GameData/KerbalismConfig/Profiles/ROKerbalism.cfg
+++ b/GameData/KerbalismConfig/Profiles/ROKerbalism.cfg
@@ -1464,7 +1464,7 @@ Supply
 	{
 		name = ProcessController
 		resource = _MRPLarge
-		title = Molten Regolith Pyrolosis
+		title = molten regolith pyrolosis (lg)
 		capacity = 1
 		running = true
 	}
@@ -1518,7 +1518,7 @@ Supply
 		}
 		SETUP
 		{
-			name = molten regolith pyrolosis (lg)
+			name = Molten Regolith Pyrolosis
 			desc = <b>Ore</b> is superheated and the contained oxides release <b>Oxygen</b>, the remaining metal is discarded.
 			tech = lifeSupportNF
 			mass = 0.1
@@ -1562,14 +1562,6 @@ Supply
 			}
 		}
 	}
-}
-
-@PART[kerbalism-chemicalplant]:NEEDS[ProfileRealismOverhaul]:FOR[Kerbalism]
-{
-  @MODULE[ProcessController],*
-  {
-    @capacity *= 2.0
-  }
 }
 
 // ============================================================================

--- a/GameData/KerbalismConfig/Profiles/ROKerbalism.cfg
+++ b/GameData/KerbalismConfig/Profiles/ROKerbalism.cfg
@@ -333,20 +333,6 @@ Supply
 		dump_valve = Water,Ammonia,Water&Ammonia
 	}
 
-	// source : https://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/20160003882.pdf
-	// Feces Torrefaction heats waste to 250C to recover water, CO2, and sanitize.
-	Process
-	{
-		name = waste processor
-		modifier = _WasteProcessor
-		input = ElectricCharge@0.003433333333
-		input = Waste@0.00003703703704
-		output = CarbonDioxide@0.0004698445242		//  3.3% released as CO2
-		output = Water@0.00002083333333				//  75% recovered as water
-			// Remaining mass discarded since the tar and dried waste is not something we use
-			// Feces is considered to the dominant source of Waste
-	}
-
 	Process
 	{
 		name = waste incinerator
@@ -673,14 +659,6 @@ Supply
 	}
 	MODULE
 	{
-		name = ProcessController
-		resource = _WasteProcessor
-		title = Waste Processor
-		capacity = 3
-		running = true
-	}
-	MODULE
-	{
 		name = Configure
 		title = Life Support
 		slots = 1
@@ -818,23 +796,7 @@ Supply
 				id_value = _WaterRecycler
 			}
 		}
-
-		SETUP
-		{
-			name = Waste Processor
-			desc = Extract <b>Water</b> and <b>CarbonDioxide</b> out of organic <b>Waste</b> through low temperature torrefaction.
-			tech = efficientLifeSupport
-			mass = 0.02 //FIXME
-			cost = 50 //FIXME
-
-			MODULE
-			{
-				type = ProcessController
-				id_field = resource
-				id_value = _WasteProcessor
-			}
-		}
-  }
+	}
 }
 
 // ============================================================================
@@ -1860,13 +1822,6 @@ RESOURCE_DEFINITION
 RESOURCE_DEFINITION
 {
   name = _WaterRecycler
-  density = 0.0
-  isVisible = false
-}
-
-RESOURCE_DEFINITION
-{
-  name = _WasteProcessor
   density = 0.0
   isVisible = false
 }

--- a/GameData/KerbalismConfig/Profiles/ROKerbalism.cfg
+++ b/GameData/KerbalismConfig/Profiles/ROKerbalism.cfg
@@ -498,24 +498,24 @@ Supply
 		output = LqdOxygen@0.00006228235886
 	}
 
-	// convention: 1 capacity = enough to liquify the output of 1 electrolizer (~1 g/s)
+	// convention: 1 capacity = enough to feed SE-RWGS
 	Process
 	{
 		name = lh2 to h2 converter
 		modifier = _LH2Converter
-		input = LqdHydrogen@0.0141
-		input = ElectricCharge@2.11
-		output = Hydrogen@11.1121802
+		input = LqdHydrogen@0.001325490486
+		input = ElectricCharge@.01 // FIXME
+		output = Hydrogen@1.044616251
 	}
 
-	// convention: 1 capacity = ~1 liter LH2 per hour
+	// convention: 1 capacity = enough to liquify the output of 1 electrolizer
 	Process
 	{
 		name = h2 to lh2 converter
 		modifier = _H2Converter
-		input = Hydrogen@2.206674082
-		input = ElectricCharge@0.143	// 143W for 70g/hr, interpolated - source: https://www.hydrogen.energy.gov/pdfs/19001_hydrogen_liquefaction_costs.pdf
-		output = LqdHydrogen@0.00028
+		input = Hydrogen@0.042
+		input = ElectricCharge@0.08835372	// source: https://cordis.europa.eu/project/id/278177/reporting/pl 6.5kWh/kg
+		output = LqdHydrogen@0.00005329287227
 	}
 
 	Process
@@ -640,6 +640,15 @@ Supply
 		capacity = 3
 		running = true
 	}
+	MODULE
+    {
+  	name = ProcessController
+  	resource = _LOXConverter
+  	title = LOX to GOX Converter
+  	capacity = 3
+  	running = true
+    }
+
 	MODULE
 	{
 		name = Configure
@@ -779,6 +788,21 @@ Supply
 				id_value = _WaterRecycler
 			}
 		}
+		SETUP
+	    {
+	      name = LOX to GOX Converter
+	      desc = Heats <b>LqdOxygen</b> to breathable <b>Oxygen</b>.
+		  tech = earlyLifeSupport
+		  mass = 0.005 //FIXME
+	      cost = 20 //FIXME
+
+	      MODULE
+	      {
+	        type = ProcessController
+	        id_field = resource
+	        id_value = _LOXConverter
+	      }
+	    }
 	}
 }
 
@@ -1116,15 +1140,6 @@ Supply
 	running = true
   }
 
-  MODULE
-  {
-	name = ProcessController
-	resource = _LOXConverter
-	title = LOX to GOX Converter
-	capacity = 10
-	running = true
-  }
-
 	MODULE
 	{
 	  name = Harvester
@@ -1245,21 +1260,6 @@ Supply
 //        id_value = _WasteIncinerator
 //      }
 //    }
-	SETUP
-    {
-      name = LOX to GOX Converter
-      desc = Heats <b>LqdOxygen</b> to breathable <b>Oxygen</b>.
-	  tech = earlyLifeSupport
-	  mass = 0.01 //FIXME
-      cost = 20 //FIXME
-
-      MODULE
-      {
-        type = ProcessController
-        id_field = resource
-        id_value = _LOXConverter
-      }
-    }
 	SETUP
 		{
 			name = CO2 Filter
@@ -1591,6 +1591,15 @@ Supply
 	}
 
 	MODULE
+    {
+	  	name = ProcessController
+	  	resource = _LOXConverter
+	  	title = LOX to GOX Converter
+	  	capacity = 10
+	  	running = true
+    }
+
+	MODULE
 	{
 		name = ProcessController
 		resource = _LH2Converter
@@ -1604,7 +1613,7 @@ Supply
 		name = ProcessController
 		resource = _H2Converter
 		title = GH2 to LH2 Converter
-		capacity = 3
+		capacity = 4
 		running = true
 	}
 	MODULE
@@ -1634,6 +1643,21 @@ Supply
 				id_value = _OXConverter
 			}
 		}
+		SETUP
+	    {
+	      name = LOX to GOX Converter
+	      desc = Heats <b>LqdOxygen</b> to breathable <b>Oxygen</b>.
+		  tech = earlyLifeSupport
+		  mass = 0.01 //FIXME
+	      cost = 20 //FIXME
+
+	      MODULE
+	      {
+	        type = ProcessController
+	        id_field = resource
+	        id_value = _LOXConverter
+	      }
+	    }
 		SETUP
 		{
 			name = LH2 to GH2 Converter

--- a/GameData/KerbalismConfig/Profiles/ROKerbalism.cfg
+++ b/GameData/KerbalismConfig/Profiles/ROKerbalism.cfg
@@ -438,14 +438,32 @@ Supply
 	}
 
 	//  source: https://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/20150016088.pdf
-	//  scaled to 1/12 to match 3 Kerbal Oxygen needs.
+	//  3 processes since both mass and efficiency change with size.
 	Process
 	{
-		name = molten regolith pyrolosis
-		modifier = _MRP
+		name = molten regolith pyrolosis (ls)
+		modifier = _MRPCrew
 		input = ElectricCharge@1.4
-		input = Ore@0.000002243181818
+		input = Regolith@0.000002243181818
 		output = Oxygen@0.007 //44% oxygen recovered, remaining mass discarded
+	}
+
+	Process
+	{
+		name = molten regolith pyrolosis (sm)
+		modifier = _MRPSmall
+		input = ElectricCharge@13
+		input = Regolith@0.00001801692726
+		output = Oxygen@0.05622303543 //44% oxygen recovered, remaining mass discarded
+	}
+
+	Process
+	{
+		name = molten regolith pyrolosis (lg)
+		modifier = _MRPLarge
+		input = ElectricCharge@58
+		input = Regolith@0.00009008463632
+		output = Oxygen@0.2811151772 //44% oxygen recovered, remaining mass discarded
 	}
 
 	//  source: https://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/20170001808.pdf
@@ -458,6 +476,20 @@ Supply
 		input = CarbonDioxide@0.01409853921
 		output = Oxygen@0.007092198582
 		//output = CarbonMonoxide@0.014005 //discarded since we don't use it yet
+	}
+
+	//  source: https://pdfs.semanticscholar.org/9159/213d6ad79bd800d07525bc37463588742662.pdf
+	//  convention: 1 capacity = 22 tons in 300 days with 50% uptime, roughly 1/5th Mars Direct or enough for a large unmanned return
+	Process
+	{
+		name = SE-RWGS
+		modifier = _RWGS
+		input = ElectricCharge@4.164547812
+		input = CarbonDioxide@0.8433582486
+		input = Hydrogen@1.044616251
+		output = LqdMethane@0.0008827766639
+		output = LqdOxygen@0.001185518392
+		dump_valve = LqdMethane,LqdOxygen
 	}
 
 	Process
@@ -492,9 +524,9 @@ Supply
 	{
 		name = ox to lox converter
 		modifier = _OXConverter
-		input = Oxygen@0.125104279
-		input = ElectricCharge@0.8291478 // Best option 2873 W for 2.2kg/hr source: https://www.sciencedirect.com/science/article/pii/S0011227517302187
-		output = LqdOxygen@0.000154599
+		input = Oxygen@0.05622303543
+		input = ElectricCharge@0.3726267919 // Best option 2873 W for 2.2kg/hr source: https://www.sciencedirect.com/science/article/pii/S0011227517302187
+		output = LqdOxygen@0.00006947823947
 	}
 
 	// convention: 1 capacity = enough to liquify the output of 1 electrolizer (~1 g/s)
@@ -610,14 +642,6 @@ Supply
 	MODULE
 	{
 		name = ProcessController
-		resource = _MOXIE
-		title = MOXIE
-		capacity = 3
-		running = true
-	}
-	MODULE
-	{
-		name = ProcessController
 		resource = _PressureControl
 		title = N2 Pressure Controller
 		capacity = 3
@@ -655,35 +679,11 @@ Supply
 		capacity = 3
 		running = true
 	}
-	//Adding Atmospheric filter modules to life support unit
-	MODULE
-	{
-	  name = Harvester
-	  title = CO2 Filter
-	  type = 2
-	  resource = CarbonDioxide
-	  min_abundance = 0.9
-	  min_pressure = 0.4
-	  abundance_rate = 0.9
-	  rate = 0.043
-	  ec_rate = 1.5
-	}
-
 	MODULE
 	{
 		name = Configure
 		title = Life Support
-		slots = 2
-
-		UPGRADES
-		{
-			UPGRADE
-			{
-				name__ = Upgrade-Slots
-				techRequired__ = improvedLifeSupport
-				slots = 3
-			}
-    	}
+		slots = 1
 
 		SETUP
 		{
@@ -752,22 +752,6 @@ Supply
 				type = ProcessController
 				id_field = resource
 				id_value = _AdvScrubber
-			}
-		}
-
-		SETUP
-		{
-			name = MOXIE
-			desc = <b>M</b>ars <b>Ox</b>ygen <b>I</b>SRU <b>E</b>xperiment breaks down <b>CarbonDioxide</b> to produce <b>Oxygen</b> and discards leftover <b>Carbon Monoxide</b>.
-			tech = advancedLifeSupport
-			mass = 0.03
-			cost = 20 //FIXME
-
-			MODULE
-			{
-				type = ProcessController
-				id_field = resource
-				id_value = _MOXIE
 			}
 		}
 
@@ -850,24 +834,7 @@ Supply
 				id_value = _WasteProcessor
 			}
 		}
-
-		//Adding setups for atmospheric filters
-		SETUP
-		{
-			name = CO2 Filter
-			desc = A <b>CO2</b> harvesting unit meant to feed a MOXIE process.
-			tech = longTermLifeSupport
-			mass = 0.06
-			cost = 50 //FIXME
-
-			MODULE
-			{
-			type = Harvester
-			id_field = resource
-			id_value = CarbonDioxide
-			}
-		}
-  	}
+  }
 }
 
 // ============================================================================
@@ -1138,7 +1105,7 @@ Supply
 // ============================================================================
 // Basic ISRU Chemical Plant (Experimental!!)
 // ============================================================================
-@PART[kerbalism-chemicalplant,MiniISRU,ISRU]:NEEDS[ProfileRealismOverhaul]:FOR[Kerbalism]
+@PART[kerbalism-chemicalplant]:NEEDS[ProfileRealismOverhaul]:FOR[Kerbalism]
 {
   !MODULE[ModuleResourceConverter]:HAS[#ConverterName[Lf+Ox]] {}
   !MODULE[ModuleResourceConverter]:HAS[#ConverterName[LiquidFuel]] {}
@@ -1164,7 +1131,7 @@ Supply
 	name = ProcessController
 	resource = _WaterElectrolysis
 	title = Water electrolysis
-	capacity = 1
+	capacity = 3
 	running = true
   }
 
@@ -1176,6 +1143,15 @@ Supply
 	capacity = 1
 	running = true
   }
+
+	MODULE
+	{
+		name = ProcessController
+		resource = _MOXIE
+		title = MOXIE
+		capacity = 3
+		running = true
+	}
 
   MODULE
   {
@@ -1189,18 +1165,9 @@ Supply
   MODULE
   {
 	name = ProcessController
-	resource = _algae
-	title = Algae Bioreactor
-	capacity = 1
-	running = true
-  }
-
-  MODULE
-  {
-	name = ProcessController
-	resource = _MRP
-	title = Molten Regolith Pyrolosis
-	capacity = 1
+	resource = _MRPCrew
+	title = molten regolith pyrolosis (ls)
+	capacity = 3
 	running = true
   }
 
@@ -1213,48 +1180,24 @@ Supply
 	running = true
   }
 
-  MODULE
-  {
-	name = ProcessController
-	resource = _OXConverter
-	title = GOX to LOX Converter
-	capacity = 1
-	running = true
-  }
-
-  MODULE
-  {
-	name = ProcessController
-	resource = _LH2Converter
-	title = LH2 to GH2 Converter
-	capacity = 1
-	running = true
-  }
-
-  MODULE
-  {
-	name = ProcessController
-	resource = _H2Converter
-	title = GH2 to LH2 Converter
-	capacity = 1
-	running = true
-  }
+	MODULE
+	{
+	  name = Harvester
+	  title = CO2 Filter
+	  type = 2
+	  resource = CarbonDioxide
+	  min_abundance = 0.9
+	  min_pressure = 0.4
+	  abundance_rate = 0.9
+	  rate = 0.043
+	  ec_rate = 1.5
+	}
 
   MODULE
   {
     name = Configure
     title = Chemical Plant
     slots = 1
-
-    UPGRADES
-    {
-      UPGRADE
-      {
-        name__ = Upgrade-Slots
-        techRequired__ = longTermLifeSupport
-        slots = 0
-      }
-    }
 
 	SETUP
 	{
@@ -1267,7 +1210,7 @@ Supply
       name = Water Electrolysis
       desc = Split <b>Water</b> into its <b>Hydrogen</b> and <b>Oxygen</b> components.
 	  tech = longTermLifeSupport
-	  mass = 0.17 // ISS OGS is 676 kgs for 4 crew
+	  mass = 0.54 // ISS OGS is 676 kgs for 4 crew
       cost = 50 //FIXME
 
       MODULE
@@ -1294,52 +1237,52 @@ Supply
       }
     }
 
+		SETUP
+		{
+			name = MOXIE
+			desc = <b>M</b>ars <b>Ox</b>ygen <b>I</b>SRU <b>E</b>xperiment breaks down <b>CarbonDioxide</b> to produce <b>Oxygen</b> and discards leftover <b>Carbon Monoxide</b>.
+			tech = advancedLifeSupport
+			mass = 0.03
+			cost = 20 //FIXME
+
+			MODULE
+			{
+				type = ProcessController
+				id_field = resource
+				id_value = _MOXIE
+			}
+		}
+
 	SETUP
     {
-	name = Plasma Methane Pyrolosis
-	desc = <b>LqdMethane</b> is heated and recombined into <b>Hydrogen</b> and <b>Ethylene</b> allowing for more hydrogen recovery from Sabatier reactions.
-	tech = efficientLifeSupport
-	mass = 0.05
-	cost = 50 //FIXME
+		name = Plasma Methane Pyrolosis
+		desc = <b>LqdMethane</b> is heated and recombined into <b>Hydrogen</b> and <b>Ethylene</b> allowing for more hydrogen recovery from Sabatier reactions.
+		tech = advancedLifeSupport
+		mass = 0.05
+		cost = 50 //FIXME
 
-	MODULE
-	{
-	  type = ProcessController
-	  id_field = resource
-	  id_value = _CH4Pyrolosis
-	}
+		MODULE
+		{
+		  type = ProcessController
+		  id_field = resource
+		  id_value = _CH4Pyrolosis
+		}
   }
 
   SETUP
   {
-	name = Algae Bioreactor
-	desc = Algae consumes <b>WasteWater</b> and <b>WasteAtmosphere</b> to produce <b>Oxygen</b> and multiply, excess algae is processed into <b>Food</b> and <b>Water</b>.
-	tech = efficientLifeSupport
-	mass = .12
-	cost = 50 //FIXME
+		name = Molten Regolith Pyrolosis
+		desc = <b>Ore</b> is superheated and the contained oxides release <b>Oxygen</b>, the remaining metal is discarded.
+		tech = longTermLifeSupport
+		mass = 0.04
+		cost = 50 //FIXME
 
-	MODULE
-	{
-	  type = ProcessController
-	  id_field = resource
-	  id_value = _algae
-	}
-  }
-
-  SETUP
-  {
-	name = Molten Regolith Pyrolosis
-	desc = <b>Ore</b> is superheated and the contained oxides release <b>Oxygen</b>, the remaining metal is discarded.
-	tech = advancedLifeSupport
-	mass = 0.2 //Production scaled to 1/12th from sourced reactor to match 3 Kerbals, mass scaled to 1/2 since reactor efficiency drops with size.
-	cost = 50 //FIXME
-
-	MODULE
-	{
-	  type = ProcessController
-	  id_field = resource
-	  id_value = _MRP
-	}
+		MODULE
+		{
+		  type = ProcessController
+		  id_field = resource
+		  id_value = _MRPCrew
+		}
   }
 
 //  SETUP
@@ -1373,71 +1316,275 @@ Supply
       }
     }
 	SETUP
-    {
-      name = GOX to LOX Converter
-      desc = Liquifies breathable <b>Oxygen</b> into <b>LqdOxygen</b>.
-	  tech = lifeSupportISRU
-	  mass = 0.017 // Best option processes 2.2kg/hr w/mass of 68kg source: https://www.sciencedirect.com/science/article/pii/S0011227517302187
-      cost = 50 //FIXME
+		{
+			name = CO2 Filter
+			desc = A <b>CO2</b> harvesting unit meant to feed a MOXIE process.
+			tech = longTermLifeSupport
+			mass = 0.06
+			cost = 50 //FIXME
 
-      MODULE
-      {
-        type = ProcessController
-        id_field = resource
-        id_value = _OXConverter
-      }
-    }
-	SETUP
-    {
-      name = LH2 to GH2 Converter
-      desc = Heats <b>LqdHydrogen</b> to gaseous <b>Hydrogen</b>.
-	  tech = longTermLifeSupport
-	  mass = 0.01 //FIXME
-      cost = 20 //FIXME
-
-      MODULE
-      {
-        type = ProcessController
-        id_field = resource
-        id_value = _LH2Converter
-      }
-    }
-	SETUP
-    {
-      name = GH2 to LH2 Converter
-      desc = Liquifies gaseous <b>Hydrogen</b> into <b>LqdHydrogen</b>.
-	  tech = longTermLifeSupport
-	  mass = 0.034 //FIXME 2x the Ox liquifier's mass - ~1/2 liter/s, ~4x more mass/liter (???)
-      cost = 100 //FIXME
-
-      MODULE
-      {
-        type = ProcessController
-        id_field = resource
-        id_value = _H2Converter
-      }
-    }
-  }
+			MODULE
+			{
+				type = Harvester
+				id_field = resource
+				id_value = CarbonDioxide
+			}
+		}
+	}
 }
-@PART[MiniISRU]:NEEDS[ProfileRealismOverhaul]:FOR[Kerbalism]
+@PART[kerbalism-miniISRU]:NEEDS[ProfileRealismOverhaul]:FOR[Kerbalism]
+{
+	%RSSROConfig = true
+	MODULE
+	{
+		name = ProcessController
+		resource = _RWGS
+		title = SE-RWGS
+		capacity = 1
+		running = true
+	}
+	MODULE
+	{
+		name = ProcessController
+		resource = _MRPSmall
+		title = molten regolith pyrolosis (sm)
+		capacity = 1
+		running = true
+	}
+	MODULE
+	{
+		name = Harvester
+		title = CO2 Sorption Pump
+		type = 2
+		resource = CarbonDioxide
+		min_abundance = 0.9
+		min_pressure = 0.4
+		abundance_rate = 0.9
+		rate = 0.84
+		ec_rate = 0.35
+	}
+
+	MODULE
+	{
+		name = ProcessController
+		resource = _WaterElectrolysis
+		title = Water electrolysis
+		capacity = 12
+		running = true
+	}
+
+	MODULE
+	{
+	    name = Configure
+	    title = Mini ISRU
+	    slots = 2
+
+		SETUP
+		{
+			name = None
+			desc = Empty slot for mass and cost savings, should you not require any experiments installed.
+		}
+
+		SETUP
+		{
+	    	name = SE-RWGS
+	    	desc = A Sabatier Electrolysis system with added Reverse Water Gas Shift for better conversion of <b>CarbonDioxide</b> and <b>Hydrogen</b> directly into <b>LqdOxygen</b> and <b>LqdMethane</b>.
+		  	tech = efficientLifeSupport
+		  	mass = 0.01
+	    	cost = 50 //FIXME
+
+	      	MODULE
+	    	{
+		        type = ProcessController
+		        id_field = resource
+		        id_value = _RWGS
+	    	}
+		}
+			SETUP
+	    {
+	    	name = Molten Regolith Pyrolosis
+	    	desc = <b>Ore</b> is superheated and the contained oxides release <b>Oxygen</b>, the remaining metal is discarded.
+	  		tech = advancedLifeSupport
+		  	mass = 0.1
+	    	cost = 50 //FIXME
+
+		    MODULE
+		    {
+		        type = ProcessController
+		        id_field = resource
+		        id_value = _MRPSmall
+		    }
+	    }
+		SETUP
+		{
+			name = CO2 Sorption Pump
+			desc = An advanced <b>CO2</b> pump for feeding larger ISRU processes.
+			tech = efficientLifeSupport
+			mass = 0.01
+			cost = 50 //FIXME
+
+			MODULE
+			{
+				type = Harvester
+				id_field = resource
+				id_value = CarbonDioxide
+			}
+		}
+		SETUP
+		{
+			name = Water Electrolysis
+			desc = Split <b>Water</b> into its <b>Hydrogen</b> and <b>Oxygen</b> components.
+			tech = advancedLifeSupport
+			mass = .5 // FIXME
+			cost = 50 //FIXME
+
+			MODULE
+			{
+				type = ProcessController
+				id_field = resource
+				id_value = _WaterElectrolysis
+			}
+		}
+	}
+}
+
+@PART[kerbalism-ISRU]:NEEDS[ProfileRealismOverhaul]:FOR[Kerbalism]
+{
+	%RSSROConfig = true
+
+	MODULE
+	{
+		name = ProcessController
+		resource = _RWGS
+		title = SE-RWGS
+		capacity = 5
+		running = true
+	}
+	MODULE
+	{
+		name = ProcessController
+		resource = _MRPLarge
+		title = Molten Regolith Pyrolosis
+		capacity = 1
+		running = true
+	}
+	MODULE
+	{
+		name = Harvester
+		title = CO2 Sorption Pump
+		type = 2
+		resource = CarbonDioxide
+		min_abundance = 0.9
+		min_pressure = 0.4
+		abundance_rate = 0.9
+		rate = 4.2
+		ec_rate = 1.8
+	}
+	MODULE
+	{
+		name = ProcessController
+		resource = _WaterElectrolysis
+		title = Water Electrolysis
+		capacity = 60
+		running = true
+	}
+
+	MODULE
+	{
+		name = Configure
+		title = ISRU
+		slots = 2
+
+		SETUP
+		{
+			name = None
+			desc = Empty slot for mass and cost savings, should you not require any experiments installed.
+		}
+
+		SETUP
+		{
+			name = SE-RWGS
+			desc = A Sabatier Electrolysis system with added Reverse Water Gas Shift for better conversion of <b>CarbonDioxide</b> and <b>Hydrogen</b> directly into <b>LqdOxygen</b> and <b>LqdMethane</b>.
+			tech = lifeSupportNF
+			mass = 0.01
+			cost = 50 //FIXME
+
+			MODULE
+			{
+				type = ProcessController
+				id_field = resource
+				id_value = _RWGS
+			}
+		}
+		SETUP
+		{
+			name = molten regolith pyrolosis (lg)
+			desc = <b>Ore</b> is superheated and the contained oxides release <b>Oxygen</b>, the remaining metal is discarded.
+			tech = lifeSupportNF
+			mass = 0.1
+			cost = 50 //FIXME
+
+			MODULE
+			{
+				type = ProcessController
+				id_field = resource
+				id_value = _MRPLarge
+			}
+		}
+		SETUP
+		{
+			name = CO2 Sorption Pump
+			desc = An advanced <b>CO2</b> pump for feeding larger ISRU processes.
+			tech = lifeSupportNF
+			mass = 0.02
+			cost = 50 //FIXME
+
+			MODULE
+			{
+				type = Harvester
+				id_field = resource
+				id_value = CarbonDioxide
+			}
+		}
+		SETUP
+		{
+			name = Water Electrolysis
+			desc = Split <b>Water</b> into its <b>Hydrogen</b> and <b>Oxygen</b> components.
+			tech = lifeSupportNF
+			mass = 1 // FIXME
+			cost = 50 //FIXME
+
+			MODULE
+			{
+				type = ProcessController
+				id_field = resource
+				id_value = _WaterElectrolysis
+			}
+		}
+	}
+}
+
+@PART[kerbalism-chemicalplant]:NEEDS[ProfileRealismOverhaul]:FOR[Kerbalism]
 {
   @MODULE[ProcessController],*
   {
-    @capacity *= 36.0      //  2.0 * 18  (MiniISRU is 18 times bigger than the kerbalism-chemicalplant)
+    @capacity *= 2.0
   }
 }
 
-@PART[ISRU]:NEEDS[ProfileRealismOverhaul]:FOR[Kerbalism]
-{
-  @MODULE[ProcessController],*
-  {
-    @capacity *= 90.0     //  36.0 * 5 / 2  (ISRU is 5 times bigger than the MiniISRU but has double the slots)
-  }
+// ============================================================================
+// Configure Upgrade Slots
+// ============================================================================
 
-  @MODULE[Configure]
-  {
-    %slots = 2
-  }
+// ISRU slot upgrades
+@PART[kerbalism-chemicalplant,MiniISRU,ISRU]:NEEDS[ProfileRealismOverhaul]:FOR[Kerbalism]
+{ @MODULE[Configure] { @UPGRADES { @UPGRADE { @slots = #$../../slots$
+      @slots += 1 } } }
+}
+// ECLSS slot upgrades
+@PART[kerbalism-lifesupportmodule]:NEEDS[ProfileDefault]:FOR[Kerbalism]
+{ @MODULE[Configure] { @UPGRADES { @UPGRADE { @slots = #$../../slots$
+      @slots += 1 } } }
 }
 
 
@@ -1489,6 +1636,106 @@ Supply
 		toggle = true
 	}
 	!MODULE[ModuleGenerator] {}
+}
+// ============================================================================
+// Configure Liquefaction parts
+// ============================================================================
+@PART[Liquifier,LiquefactionArray]:NEEDS[ProfileRealismOverhaul]:FOR[Kerbalism]
+{
+	%RSSROConfig = true
+
+	MODULE
+	{
+		name = ProcessController
+		resource = _OXConverter
+		title = GOX to LOX Converter
+		capacity = 1
+		running = true
+	}
+
+	MODULE
+	{
+		name = ProcessController
+		resource = _LH2Converter
+		title = LH2 to GH2 Converter
+		capacity = 1
+		running = true
+	}
+
+	MODULE
+	{
+		name = ProcessController
+		resource = _H2Converter
+		title = GH2 to LH2 Converter
+		capacity = 3
+		running = true
+	}
+	MODULE
+  {
+    name = Configure
+    title = Liquifier
+    slots = 2
+
+		SETUP
+		{
+			name = None
+			desc = Empty slot for mass and cost savings, should you not require any experiments installed.
+		}
+
+		SETUP
+		{
+			name = GOX to LOX Converter
+			desc = Liquifies breathable <b>Oxygen</b> into <b>LqdOxygen</b>.
+			tech = lifeSupportISRU
+			mass = 0.017 //FIXME  Best option processes 2.2kg/hr w/mass of 68kg source: https://www.sciencedirect.com/science/article/pii/S0011227517302187
+			cost = 50 //FIXME
+
+			MODULE
+			{
+				type = ProcessController
+				id_field = resource
+				id_value = _OXConverter
+			}
+		}
+		SETUP
+		{
+			name = LH2 to GH2 Converter
+			desc = Heats <b>LqdHydrogen</b> to gaseous <b>Hydrogen</b>.
+			tech = advancedLifeSupport
+			mass = 0.05 //FIXME
+			cost = 20 //FIXME
+
+			MODULE
+			{
+				type = ProcessController
+				id_field = resource
+				id_value = _LH2Converter
+			}
+		}
+		SETUP
+		{
+			name = GH2 to LH2 Converter
+			desc = Liquifies gaseous <b>Hydrogen</b> into <b>LqdHydrogen</b>.
+			tech = advancedLifeSupport
+			mass = 0.1 //FIXME
+			cost = 100 //FIXME
+
+			MODULE
+			{
+				type = ProcessController
+				id_field = resource
+				id_value = _H2Converter
+			}
+		}
+	}
+}
+
+@PART[LiquefactionArray]:NEEDS[ProfileRealismOverhaul]:FOR[Kerbalism]
+{
+	@MODULE[ProcessController],*
+	{
+		@capacity *= 5
+	}
 }
 
 
@@ -1550,7 +1797,28 @@ RESOURCE_DEFINITION
 
 RESOURCE_DEFINITION
 {
-  name = _MRP
+  name = _MRPCrew
+  density = 0.0
+  isVisible = false
+}
+
+RESOURCE_DEFINITION
+{
+  name = _MRPSmall
+  density = 0.0
+  isVisible = false
+}
+
+RESOURCE_DEFINITION
+{
+  name = _MRPLarge
+  density = 0.0
+  isVisible = false
+}
+
+RESOURCE_DEFINITION
+{
+  name = _RWGS
   density = 0.0
   isVisible = false
 }
@@ -1708,17 +1976,17 @@ RESOURCE_DEFINITION
   !MODULE[ModuleOverheatDisplay] {}
   !MODULE[ModuleCoreHeat] {}
 
-@TechRequired = advancedLifeSupport
+@TechRequired = longTermLifeSupport
 @mass = 0.08
 @title = Regolith Harvester
-@description = A small harvesting device which harvests regolith and supplies usable oxide-rich ore.
+@description = A small harvesting device which harvests oxide-rich regolith for smelting.
   // source: https://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/20110016233.pdf
   MODULE
   {
     name =  Harvester
     title = Regolith Excavation
     type = 0
-    resource = Ore
+    resource = Regolith
     min_abundance = 0.02
     rate = 0.000111
     ec_rate = 0.2 // FIXME
@@ -1726,7 +1994,7 @@ RESOURCE_DEFINITION
 
   RESOURCE
   {
-    name = Ore
+    name = Regolith
     amount = 0
     maxAmount = 50
   }

--- a/GameData/KerbalismConfig/Profiles/ROKerbalism.cfg
+++ b/GameData/KerbalismConfig/Profiles/ROKerbalism.cfg
@@ -484,7 +484,7 @@ Supply
 	{
 		name = SE-RWGS
 		modifier = _RWGS
-		input = ElectricCharge@4.164547812
+		input = ElectricCharge@38.0630714
 		input = CarbonDioxide@0.8433582486
 		input = Hydrogen@1.044616251
 		output = LqdMethane@0.0008827766639
@@ -1390,7 +1390,7 @@ Supply
 	    	name = SE-RWGS
 	    	desc = A Sabatier Electrolysis system with added Reverse Water Gas Shift for better conversion of <b>CarbonDioxide</b> and <b>Hydrogen</b> directly into <b>LqdOxygen</b> and <b>LqdMethane</b>.
 		  	tech = efficientLifeSupport
-		  	mass = 0.01
+		  	mass = 0.1776276665
 	    	cost = 50 //FIXME
 
 	      	MODULE
@@ -1405,7 +1405,7 @@ Supply
 	    	name = Molten Regolith Pyrolosis
 	    	desc = <b>Ore</b> is superheated and the contained oxides release <b>Oxygen</b>, the remaining metal is discarded.
 	  		tech = advancedLifeSupport
-		  	mass = 0.1
+		  	mass = 0.2
 	    	cost = 50 //FIXME
 
 		    MODULE
@@ -1420,7 +1420,7 @@ Supply
 			name = CO2 Sorption Pump
 			desc = An advanced <b>CO2</b> pump for feeding larger ISRU processes.
 			tech = efficientLifeSupport
-			mass = 0.01
+			mass = 0.1194135573
 			cost = 50 //FIXME
 
 			MODULE
@@ -1506,7 +1506,7 @@ Supply
 			name = SE-RWGS
 			desc = A Sabatier Electrolysis system with added Reverse Water Gas Shift for better conversion of <b>CarbonDioxide</b> and <b>Hydrogen</b> directly into <b>LqdOxygen</b> and <b>LqdMethane</b>.
 			tech = lifeSupportNF
-			mass = 0.01
+			mass = 0.492580924
 			cost = 50 //FIXME
 
 			MODULE
@@ -1521,7 +1521,7 @@ Supply
 			name = Molten Regolith Pyrolosis
 			desc = <b>Ore</b> is superheated and the contained oxides release <b>Oxygen</b>, the remaining metal is discarded.
 			tech = lifeSupportNF
-			mass = 0.1
+			mass = 0.7
 			cost = 50 //FIXME
 
 			MODULE
@@ -1536,7 +1536,7 @@ Supply
 			name = CO2 Sorption Pump
 			desc = An advanced <b>CO2</b> pump for feeding larger ISRU processes.
 			tech = lifeSupportNF
-			mass = 0.02
+			mass = 0.2388271147
 			cost = 50 //FIXME
 
 			MODULE
@@ -1961,34 +1961,41 @@ RESOURCE_DEFINITION
 }
 
 // Adding regolith harvester for lunar ISRU
-@PART[MiniDrill]:NEEDS[ProfileRealismOverhaul]:FOR[Kerbalism]
++PART[MiniDrill]:NEEDS[ProfileRealismOverhaul]:BEFORE[Kerbalism]
 {
-  !MODULE[ModuleResourceHarvester] {}
-  !MODULE[ModuleAsteroidDrill] {}
-  !MODULE[ModuleOverheatDisplay] {}
-  !MODULE[ModuleCoreHeat] {}
+	@name = kerbalism-drill
+	@title = Regolith Harvester
+}
 
-@TechRequired = longTermLifeSupport
-@mass = 0.08
-@title = Regolith Harvester
-@description = A small harvesting device which harvests oxide-rich regolith for smelting.
-  // source: https://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/20110016233.pdf
-  MODULE
-  {
-    name =  Harvester
-    title = Regolith Excavation
-    type = 0
-    resource = Regolith
-    min_abundance = 0.02
-    rate = 0.000111
-    ec_rate = 0.2 // FIXME
-  }
 
-  RESOURCE
-  {
-    name = Regolith
-    amount = 0
-    maxAmount = 50
-  }
+@PART[kerbalism-drill]:NEEDS[ProfileRealismOverhaul]:FOR[Kerbalism]
+{
+	!MODULE[ModuleResourceHarvester] {}
+	!MODULE[ModuleAsteroidDrill] {}
+	!MODULE[ModuleOverheatDisplay] {}
+	!MODULE[ModuleCoreHeat] {}
+	%RSSROConfig = true
+
+	@TechRequired = longTermLifeSupport
+	@mass = 0.08
+	@description = A small harvesting device which harvests oxide-rich regolith for smelting.
+	// source: https://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/20110016233.pdf
+	MODULE
+	{
+	    name =  Harvester
+	    title = Regolith Excavation
+	    type = 0
+	    resource = Regolith
+	    min_abundance = 0.02
+	    rate = 0.000111
+	    ec_rate = 0.2 // FIXME
+	}
+
+	RESOURCE
+	{
+	    name = Regolith
+	    amount = 0
+	    maxAmount = 50
+	}
 
 }

--- a/GameData/KerbalismConfig/Profiles/ROKerbalism.cfg
+++ b/GameData/KerbalismConfig/Profiles/ROKerbalism.cfg
@@ -427,29 +427,11 @@ Supply
 	//  3 processes since both mass and efficiency change with size.
 	Process
 	{
-		name = molten regolith pyrolosis (ls)
-		modifier = _MRPCrew
-		input = ElectricCharge@1.4
-		input = Regolith@0.000002243181818
+		name = molten regolith pyrolosis
+		modifier = _MRP
+		input = ElectricCharge@1.444247885
+		input = Regolith@0.0000027667584
 		output = Oxygen@0.007 //44% oxygen recovered, remaining mass discarded
-	}
-
-	Process
-	{
-		name = molten regolith pyrolosis (sm)
-		modifier = _MRPSmall
-		input = ElectricCharge@13
-		input = Regolith@0.00001801692726
-		output = Oxygen@0.05622303543 //44% oxygen recovered, remaining mass discarded
-	}
-
-	Process
-	{
-		name = molten regolith pyrolosis (lg)
-		modifier = _MRPLarge
-		input = ElectricCharge@58
-		input = Regolith@0.00009008463632
-		output = Oxygen@0.2811151772 //44% oxygen recovered, remaining mass discarded
 	}
 
 	//  source: https://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/20170001808.pdf
@@ -506,13 +488,14 @@ Supply
 		output = Oxygen@0.0125104279
 	}
 
+	// convention: 1 capacity = 90% of MRP output to keep it from liquifying life support supplies
 	Process
 	{
 		name = ox to lox converter
 		modifier = _OXConverter
-		input = Oxygen@0.05622303543
-		input = ElectricCharge@0.3726267919 // Best option 2873 W for 2.2kg/hr source: https://www.sciencedirect.com/science/article/pii/S0011227517302187
-		output = LqdOxygen@0.00006947823947
+		input = Oxygen@0.0504
+		input = ElectricCharge@0.334 // Best option 2873 W for 2.2kg/hr source: https://www.sciencedirect.com/science/article/pii/S0011227517302187
+		output = LqdOxygen@0.00006228235886
 	}
 
 	// convention: 1 capacity = enough to liquify the output of 1 electrolizer (~1 g/s)
@@ -1127,8 +1110,8 @@ Supply
   MODULE
   {
 	name = ProcessController
-	resource = _MRPCrew
-	title = molten regolith pyrolosis (ls)
+	resource = _MRP
+	title = molten regolith pyrolosis
 	capacity = 3
 	running = true
   }
@@ -1243,7 +1226,7 @@ Supply
 		{
 		  type = ProcessController
 		  id_field = resource
-		  id_value = _MRPCrew
+		  id_value = _MRP
 		}
   }
 
@@ -1308,9 +1291,9 @@ Supply
 	MODULE
 	{
 		name = ProcessController
-		resource = _MRPSmall
-		title = molten regolith pyrolosis (sm)
-		capacity = 1
+		resource = _MRP
+		title = molten regolith pyrolosis
+		capacity = 8
 		running = true
 	}
 	MODULE
@@ -1374,7 +1357,7 @@ Supply
 		    {
 		        type = ProcessController
 		        id_field = resource
-		        id_value = _MRPSmall
+		        id_value = _MRP
 		    }
 	    }
 		SETUP
@@ -1425,9 +1408,9 @@ Supply
 	MODULE
 	{
 		name = ProcessController
-		resource = _MRPLarge
-		title = molten regolith pyrolosis (lg)
-		capacity = 1
+		resource = _MRP
+		title = molten regolith pyrolosis
+		capacity = 40
 		running = true
 	}
 	MODULE
@@ -1490,7 +1473,7 @@ Supply
 			{
 				type = ProcessController
 				id_field = resource
-				id_value = _MRPLarge
+				id_value = _MRP
 			}
 		}
 		SETUP
@@ -1751,21 +1734,7 @@ RESOURCE_DEFINITION
 
 RESOURCE_DEFINITION
 {
-  name = _MRPCrew
-  density = 0.0
-  isVisible = false
-}
-
-RESOURCE_DEFINITION
-{
-  name = _MRPSmall
-  density = 0.0
-  isVisible = false
-}
-
-RESOURCE_DEFINITION
-{
-  name = _MRPLarge
+  name = _MRP
   density = 0.0
   isVisible = false
 }

--- a/GameData/KerbalismConfig/Support/RealFuels.cfg
+++ b/GameData/KerbalismConfig/Support/RealFuels.cfg
@@ -21,3 +21,19 @@
 		@rated_operation_duration = 0
 	}
 }
+
+// add Hydrogen to SM tanks
+@TANK_DEFINITION[SM-*]
+{
+	TANK
+	{
+		name = Hydrogen
+		mass = 0.00003
+		utilization = 100
+		fillable = True
+		amount = 0.0
+		maxAmount = 0.0
+		note = (pressurized)
+		cost = 0.0025
+	}
+}

--- a/GameData/KerbalismConfig/Support/Restock.cfg
+++ b/GameData/KerbalismConfig/Support/Restock.cfg
@@ -1,0 +1,22 @@
+
+@PART[kerbalism-ISRU,kerbalism-miniISRU]:NEEDS[ReStock]:AFTER[Kerbalism]
+{
+    @MODEL
+    {
+        @model = ReStock/Assets/Resource/restock-isru-125-1
+    }
+}
+@PART[Liquifier]:NEEDS[ReStock]:AFTER[Kerbalism]
+{
+    @MODEL
+    {
+        @model = ReStock/Assets/Electrical/restock-fuelcell-radial-1
+    }
+}
+@PART[LiquefactionArray]:NEEDS[ReStock]:AFTER[Kerbalism]
+{
+    @MODEL
+    {
+        @model = ReStock/Assets/Electrical/restock-fuelcell-radial-2
+    }
+}


### PR DESCRIPTION
Added Liquefaction and ISRU parts.
Moved LS processes to balance between ECLSS and chem plant.
Changed ECLSS and chem plant to 1 slot.
Added Hydrogen to available service module tanks.
Split MRP into 3 processes so that it scales correctly.
Added Real ISRU SE-RWGS process.
Scaled larger ISRU processes to roughly match unmanned (mini) or manned (isru) return needs in 300 days.
Changed MRP and harvester to use regolith since SCANsat sees it now.