### PR TITLE
Nerf Advanced Capsule

### DIFF
--- a/GameData/KerbalismConfig/System/Parts.cfg
+++ b/GameData/KerbalismConfig/System/Parts.cfg
@@ -806,7 +806,7 @@
   }
 }
 //Gemini SM
-@PART[ROC-GeminiEquipmentSection|ROC-GeminiEquipmentSectionBDB|FASAGeminiUtilityPack|ROAdvCapsule]:NEEDS[ProfileRealismOverhaul]:AFTER[RealismOverhaul]
+@PART[ROC-GeminiEquipmentSection|ROC-GeminiEquipmentSectionBDB|FASAGeminiUtilityPack]:NEEDS[ProfileRealismOverhaul]:AFTER[RealismOverhaul]
 {
   MODULE
   {


### PR DESCRIPTION
Integrating a fuel cell and LOX to GOX converter into the Advanced Capsule resulted in it becoming significantly cheaper and lighter than a Gemini with a service module for the same capabilities. Remove the Fuel Cell and LOX to GOX converter to make it more balanced