### PR TITLE
Recycler holding tanks

### DIFF
--- a/GameData/KerbalismConfig/Profiles/ROKerbalism.cfg
+++ b/GameData/KerbalismConfig/Profiles/ROKerbalism.cfg
@@ -1243,7 +1243,13 @@ Supply
 				id_field = resource
 				id_value = _CH4Pyrolosis
 			}
-	}
+			RESOURCE
+			{
+				name = LqdMethane
+				amount = 0
+				maxAmount = 3
+			}
+		}
 
 		SETUP
 		{
@@ -1259,6 +1265,12 @@ Supply
 				id_field = resource
 				id_value = _MRP
 			}
+			RESOURCE
+			{
+				name = Regolith
+				amount = 0
+				maxAmount = 1
+			}
 		}
 
 		SETUP
@@ -1268,7 +1280,7 @@ Supply
 			tech = efficientLifeSupport
 			mass = 0.05 //FIXME
 			cost = 50 //FIXME
-		
+
 			MODULE
 			{
 				type = ProcessController
@@ -1377,6 +1389,12 @@ Supply
 		        id_field = resource
 		        id_value = _MRP
 		    }
+			RESOURCE
+			{
+				name = Regolith
+				amount = 0
+				maxAmount = 8
+			}
 	    }
 		SETUP
 		{
@@ -1493,6 +1511,12 @@ Supply
 				type = ProcessController
 				id_field = resource
 				id_value = _MRP
+			}
+			RESOURCE
+			{
+				name = Regolith
+				amount = 0
+				maxAmount = 40
 			}
 		}
 		SETUP
@@ -1676,6 +1700,12 @@ Supply
 				id_field = resource
 				id_value = _OXConverter
 			}
+			RESOURCE
+			{
+				name = Oxygen
+				amount = 0
+				maxAmount = 500
+			}
 		}
 		SETUP
 		{
@@ -1705,6 +1735,12 @@ Supply
 				type = ProcessController
 				id_field = resource
 				id_value = _H2Converter
+			}
+			RESOURCE
+			{
+			    name = Hydrogen
+			    amount = 0
+			    maxAmount = 4500
 			}
 		}
 	}

--- a/GameData/KerbalismConfig/Profiles/ROKerbalism.cfg
+++ b/GameData/KerbalismConfig/Profiles/ROKerbalism.cfg
@@ -482,7 +482,7 @@ Supply
 	// since heating up oxygen could be completely passive or completely active based on external temperature, we make 2 assumptions:
 	// 1. the external temperature is high enough that O2 is always above its critical point (90K) (so that vaporization is free)
 	// 2. we have to bring the gaseous O2 from external ambient temp to room temperature
-	// the EC consumption is therefore defined as the power needed to heat oxygen from external temp to internal temp (20° C)
+	// the EC consumption is therefore defined as the power needed to heat oxygen from external temp to internal temp (20ï¿½ C)
 	// O2 isochoric specific heat = ~1300 J/(Kg*K) for 0.01764 g/s => 0.023 W/K * 203 K = 4.67 W
 	Process
 	{
@@ -507,7 +507,7 @@ Supply
 	// since heating up hydrogen could be completely passive or completely active based on external temperature, we make 2 assumptions:
 	// 1. the external temperature is high enough that H2 is always above its critical point (20K) (so that vaporization is free)
 	// 2. we have to bring the gaseous H2 from external ambient temp to room temperature
-	// the EC consumption is therefore defined as the power needed to heat hydrogen from external temp to internal temp (20° C)
+	// the EC consumption is therefore defined as the power needed to heat hydrogen from external temp to internal temp (20ï¿½ C)
 	// H2 isochoric specific heat = ~10 000 J/(Kg*K) for 0.094 g/s => 0.94 W/K * 313 K = 294 W
 	Process
 	{
@@ -1097,7 +1097,7 @@ Supply
   !MODULE[ModuleResourceConverter]:HAS[#ConverterName[MonoPropellant]] {}
   !MODULE[ModuleOverheatDisplay] {}
   !MODULE[ModuleCoreHeat] {}
-  
+
 
 	%RSSROConfig = true
 	%tags = _kerbalism, chemical plant, reactor, chemical, life support, process


### PR DESCRIPTION
Added small holding tanks to processes use things that may not naturally be stored on a craft with them, i.e. LqdMethane to Methane Pyrolosis.