### PR TITLE
Restore AdvBio to its original size

### DIFF
--- a/GameData/KerbalismConfig/System/Science/SatelliteScience/Experiments/bioSample.cfg
+++ b/GameData/KerbalismConfig/System/Science/SatelliteScience/Experiments/bioSample.cfg
@@ -111,7 +111,7 @@
 	@name = BioCapsule
 	%description = A capsule containing a monkey, or a small dog. Returning the sample is crucial for scientific and ethical reasons.
 	%mass = 0.05
-	%rescaleFactor = 2
+	%rescaleFactor = 1.166
 }
 
 @PART[BioCapsule]:NEEDS[FeatureScience,SXT,RP-0]:BEFORE[RP-0-Kerbalism]


### PR DESCRIPTION
ROKerbalism was relying on its rescaleFactor stacking with the
MODEL.scale applied by RO; but RO no longer sets MODEL.scale, it
sets rescaleFactor.
To get back the old size, must use a rescaleFactor that stacks
with SXT's original MODEL.scale (so 1.25 instead of 0.73)

Downside: the part will now be properly sized when paired with RO master, but will no longer be properly sized when paired with the current RO release. Seems better than the other way around to me, but it's sort of a coin flip.
