### PR TITLE
Better regolith distribution than CRP's

### DIFF
--- a/GameData/KerbalismConfig/ResourceConfigs/Regolith.cfg
+++ b/GameData/KerbalismConfig/ResourceConfigs/Regolith.cfg
@@ -1,0 +1,52 @@
+// CRP provides this default for all planets:
+//GLOBAL_RESOURCE
+//{
+//	ResourceName = Regolith
+//	ResourceType = 0
+//	Distribution
+//	{
+//		PresenceChance = 90
+//		MinAbundance = 1
+//		MaxAbundance = 20
+//		Variance = 50
+//		Dispersal = 3
+//	}
+//}
+//
+// 10% of biomes randomly getting no regolith at all can lead to some weird
+// results though, like no regolith on the mars midlands.
+// Let's use some saner defaults until somebody puts in the work of
+// researching values closer to the real-world.
+// These don't belong in RSS; their main purpose is to enable regolith
+// processes where they're meant to be usable.
+
+// FIXME: some way to avoid conflicts if RSS ever does get proper configs
+// would be nice.
+
+// Every biome gets some regolith, unless overridden by a BIOME_RESOURCE
+PLANETARY_RESOURCE
+{
+	thisIsJustATemplate = true
+	ResourceName = Regolith
+	ResourceType = 0
+	Distribution
+	{
+		PresenceChance = 100
+ 		MinAbundance = 1
+		MaxAbundance = 20
+		Variance = 50
+		Dispersal = 3
+	}
+}
+
++PLANETARY_RESOURCE:HAS[#thisIsJustATemplate,~PlanetName] { PlanetName = Moon }
++PLANETARY_RESOURCE:HAS[#thisIsJustATemplate,~PlanetName] { PlanetName = Mars }
++PLANETARY_RESOURCE:HAS[#thisIsJustATemplate,~PlanetName] { PlanetName = Phobos }
++PLANETARY_RESOURCE:HAS[#thisIsJustATemplate,~PlanetName] { PlanetName = Deimos }
++PLANETARY_RESOURCE:HAS[#thisIsJustATemplate,~PlanetName] { PlanetName = Ceres }
++PLANETARY_RESOURCE:HAS[#thisIsJustATemplate,~PlanetName] { PlanetName = Vesta }
+// TODO: add more planets, if anybody ever wants to do ISRU elsewhere.
+
+!PLANETARY_RESOURCE:HAS[#thisIsJustATemplate,~PlanetName] {}
+@PLANETARY_RESOURCE:HAS[#thisIsJustATemplate] { !thisIsJustATemplate = delete}
+


### PR DESCRIPTION
RSS has no regolith configs at all. Until it does, this
should make it easier to work with the new regolith processes