### PR TITLE
Fix NTR EC generators

### DIFF
--- a/GameData/KerbalismConfig/Profiles/ROKerbalism.cfg
+++ b/GameData/KerbalismConfig/Profiles/ROKerbalism.cfg
@@ -518,9 +518,9 @@ Supply
  	{
 		name = brayton generator
 		modifier = _BraytonGenerator
-		input = EnrichedUranium@1.0813e-15
-		output = ElectricCharge@25
-		output = DepletedUranium@1.0813e-15
+		input = EnrichedUranium@4.3252e-17
+		output = ElectricCharge@1
+		output = DepletedUranium@4.3252e-17
  	}
 
  	Process

--- a/GameData/KerbalismConfig/Support/RealismOverhaul.cfg
+++ b/GameData/KerbalismConfig/Support/RealismOverhaul.cfg
@@ -24,10 +24,6 @@
 		resource = _BraytonGenerator
 		title = Brayton Generator
 		capacity = #$../MODULE[ModuleResourceConverter]/OUTPUT_RESOURCE:HAS[#ResourceName[ElectricCharge]]/Ratio$
-		// capacity=1 == 25kW, but Ratio=1 == 1kW.
-		// FIXME: would be nice to fish the 25 out of the Process definition's "output = ElectricCharge@25"
-		//   or would it make sense to normalize the process to @1?
-		@capacity /= 25
 		running = true
 		toggle = true
 	}

--- a/GameData/KerbalismConfig/Support/RealismOverhaul.cfg
+++ b/GameData/KerbalismConfig/Support/RealismOverhaul.cfg
@@ -1,0 +1,40 @@
+@PART[*]:HAS[#engineType[NERVA,NERVAII]]:AFTER[RealismOverhaulEngines]
+{
+	MODULE
+	{
+		name = ProcessController
+		resource = _TurbineGenerator
+		title = Turbine Generator
+		capacity = #$../MODULE[ModuleResourceConverter]/OUTPUT_RESOURCE:HAS[#ResourceName[ElectricCharge]]/Ratio$
+		running = true
+		toggle = true
+	}
+	!MODULE[ModuleResourceConverter] {} // replace stock converter module
+	MODULE
+	{
+		name = Emitter
+		radiation = 0.00055555 // 2 rad/h
+	}
+}
+@PART[*]:HAS[#engineType[BNTR]]:AFTER[RealismOverhaulEngines]
+{
+	MODULE
+	{
+		name = ProcessController
+		resource = _BraytonGenerator
+		title = Brayton Generator
+		capacity = #$../MODULE[ModuleResourceConverter]/OUTPUT_RESOURCE:HAS[#ResourceName[ElectricCharge]]/Ratio$
+		// capacity=1 == 25kW, but Ratio=1 == 1kW.
+		// FIXME: would be nice to fish the 25 out of the Process definition's "output = ElectricCharge@25"
+		//   or would it make sense to normalize the process to @1?
+		@capacity /= 25
+		running = true
+		toggle = true
+	}
+	!MODULE[ModuleResourceConverter] {} // replace stock converter module
+	MODULE
+	{
+		name = Emitter
+		radiation = 0.000055555 // 0.2 rad/h
+	}
+}

--- a/GameData/KerbalismConfig/Support/SXT.cfg
+++ b/GameData/KerbalismConfig/Support/SXT.cfg
@@ -20,42 +20,6 @@
 
 	@tags ^= :$: comfort:
 }
-@PART[SXTNERVAB]:NEEDS[SXT,FeatureRadiation]
-{
-	!MODULE[ModuleResourceConverter] {} // replace stock converter module
-	MODULE
-	{
-		name = ProcessController
-		resource = _TurbineGenerator
-		title = Turbine Generator
-		capacity = 3.1
-		running = true
-		toggle = true
-	}
-	MODULE
-	{
-		name = Emitter
-		radiation = 0.00055555 // 2 rad/h
-	}
-}
-@PART[SXTNERVA]:NEEDS[SXT,FeatureRadiation]:AFTER[RealismOverhaul]
-{
-	!MODULE[ModuleResourceConverter] {} // replace stock converter module
-	MODULE
-	{
-		name = ProcessController
-		resource = _BraytonGenerator
-		title = Brayton Generator
-		capacity = 1
-		running = true
-		toggle = true
-	}
-	MODULE
-	{
-		name = Emitter
-		radiation = 0.000055555 // 0.2 rad/h
-	}
-}
 @PART[SXTnuclearramjet]:NEEDS[SXT,FeatureRadiation]
 {
 	MODULE


### PR DESCRIPTION
- Match engineType instead of part names, to support both RO's SXT parts
  and ROE's parts (and more, maybe)
- Also support NERVA I (the only other engineType with EC output)
- Extract power output from the ModuleResourceConverter instead of hardcoding
  (NERVA II was out of sync)
- Apply AFTER RO actually adds the ModuleResourceConverter
  (so we can use its value, and so we actually delete it)