### PR TITLE
Add "throttled" surface harvester configs

### DIFF
--- a/GameData/KerbalismConfig/Profiles/ROKerbalism.cfg
+++ b/GameData/KerbalismConfig/Profiles/ROKerbalism.cfg
@@ -2451,6 +2451,24 @@ RESOURCE_DEFINITION
 		rate = 0.000111
 		ec_rate = 0.2 // FIXME
 	}
+	+MODULE[Harvester]:HAS[#title[Surface?Harvester]]
+	{
+		@title ^= :$: (50%):
+		@rate /= 2
+		@ec_rate /= 2
+	}
+	+MODULE[Harvester]:HAS[#title[Surface?Harvester]]
+	{
+		@title ^= :$: (20%):
+		@rate /= 5
+		@ec_rate /= 5
+	}
+	+MODULE[Harvester]:HAS[#title[Surface?Harvester]]
+	{
+		@title ^= :$: (10%):
+		@rate /= 10
+		@ec_rate /= 10
+	}
 
 	MODULE
 	{
@@ -2472,6 +2490,24 @@ RESOURCE_DEFINITION
 		rate = 0.000134976
 		ec_rate = 2.75373
 	}
+	+MODULE[Harvester]:HAS[#title[Water?Extractor]]
+	{
+		@title = Water Extractor (50%)
+		@rate /= 2
+		@ec_rate /= 2
+	}
+	+MODULE[Harvester]:HAS[#title[Water?Extractor]]
+	{
+		@title = Water Extractor (20%)
+		@rate /= 5
+		@ec_rate /= 5
+	}
+	+MODULE[Harvester]:HAS[#title[Water?Extractor]]
+	{
+		@title = Water Extractor (10%)
+		@rate /= 10
+		@ec_rate /= 10
+	}
 	MODULE
 	{
 		name = Configure
@@ -2489,8 +2525,8 @@ RESOURCE_DEFINITION
 			MODULE
 			{
 				type = Harvester
-				id_field = resource
-				id_value = Regolith
+				id_field = title
+				id_value = Surface Harvester
 			}
 			MODULE
 			{
@@ -2505,6 +2541,39 @@ RESOURCE_DEFINITION
 				maxAmount = 5
 			}
 		}
+		+SETUP[Regolith?Harvester]
+		{
+			@name ^= :$: (50%):
+			@desc ^= :$: 50% top speed:
+			@mass *= 0.6
+
+			@MODULE:HAS[#type[Harvester]]
+			{
+				@id_value ^= :$: (50%):
+			}
+		}
+		+SETUP[Regolith?Harvester]
+		{
+			@name ^= :$: (20%):
+			@desc ^= :$: 20% top speed:
+			@mass *= 0.3
+
+			@MODULE:HAS[#type[Harvester]]
+			{
+				@id_value ^= :$: (20%):
+			}
+		}
+		+SETUP[Regolith?Harvester]
+		{
+			@name ^= :$: (10%):
+			@desc ^= :$: 10% top speed:
+			@mass *= 0.2
+
+			@MODULE:HAS[#type[Harvester]]
+			{
+				@id_value ^= :$: (10%):
+			}
+		}
 		SETUP
 		{
 			name = Water Extractor
@@ -2516,14 +2585,47 @@ RESOURCE_DEFINITION
 			MODULE
 			{
 				type = Harvester
-				id_field = resource
-				id_value = Water
+				id_field = title
+				id_value = Water Extractor
 			}
 			RESOURCE
 			{
 				name = Water
 				amount = 0
 				maxAmount = 5
+			}
+		}
+		+SETUP[Water?Extractor]
+		{
+			@name ^= :$: (50%):
+			@desc ^= :$: 50% top speed:
+			@mass *= 0.6
+
+			@MODULE:HAS[#type[Harvester]]
+			{
+				@id_value ^= :$: (50%):
+			}
+		}
+		+SETUP[Water?Extractor]
+		{
+			@name ^= :$: (20%):
+			@desc ^= :$: 20% top speed:
+			@mass *= 0.3
+
+			@MODULE:HAS[#type[Harvester]]
+			{
+				@id_value ^= :$: (20%):
+			}
+		}
+		+SETUP[Water?Extractor]
+		{
+			@name ^= :$: (10%):
+			@desc ^= :$: 10% top speed:
+			@mass *= 0.2
+
+			@MODULE:HAS[#type[Harvester]]
+			{
+				@id_value ^= :$: (10%):
 			}
 		}
 	}


### PR DESCRIPTION
Because even a mini-drill needs 2.7kW when extracting water full-speed,
and there are limits to how much downstream processes can limit it.
This allows the drill to be hard-limited to 10, 20 or 50% of
max throughput (only in the VAB, sadly)

A few things that could be done differently:
- mass is kept proportional to throughput, with a small penalty the slower it gets; there's arguments for having no penalty, for having a penalty for faster speeds, or to leave it at the full mass regardless of speeds
- ~not done for regolith because I don't have a use case~
- not done for the big drill because it's easy to just use multiple small ones if one big is too much
- specific % values could be anything, obviously
- it could instead be a single config including all values as separate harvesters (tested, it works); this would make it in-flight-configurable. But then it'd be possible to turn them all on (for 10+20+50+100=180% throughput). Could compensate by reducing each to 1/1.8, but then player would have to turn on all 4 to get full throughput, awkward. Also it'd add multiple unlabeled "simulate at abundance" sliders, more awkward

I wanted this for my own testing; may or may not be generally useful enough to merge, so putting it out there.