### PR TITLE
Fix restock'ed ISRU scale

### DIFF
--- a/GameData/KerbalismConfig/Support/Restock.cfg
+++ b/GameData/KerbalismConfig/Support/Restock.cfg
@@ -1,9 +1,22 @@
-
 @PART[kerbalism-ISRU,kerbalism-miniISRU]:NEEDS[ReStock]:AFTER[Kerbalism]
 {
     @MODEL
     {
         @model = ReStock/Assets/Resource/restock-isru-125-1
+    }
+}
+@PART[kerbalism-ISRU]:NEEDS[ReStock]:AFTER[Kerbalism]
+{
+    @MODEL
+    {
+        %scale = 1.61, 1.61, 1.61
+    }
+}
+@PART[kerbalism-miniISRU]:NEEDS[ReStock]:AFTER[Kerbalism]
+{
+    @MODEL
+    {
+        %scale = 0.8, 0.8, 0.8
     }
 }
 @PART[Liquifier]:NEEDS[ReStock]:AFTER[Kerbalism]


### PR DESCRIPTION
Seems restock's models are larger than stock's. Keeping
the same scale factor gave it inset attachment nodes.