### PR TITLE
Support NFE's lone RTG

### DIFF
--- a/GameData/KerbalismConfig/Support/NearFuture.cfg
+++ b/GameData/KerbalismConfig/Support/NearFuture.cfg
@@ -120,7 +120,7 @@ Profile
 	}
 }
 
-@PART[rtg-0625]:NEEDS[NearFutureElectrical]
+@PART[rtg-0625]:NEEDS[NearFutureElectrical]:AFTER[RealismOverhaul]
 {
 	MODULE:NEEDS[FeatureRadiation]
 	{
@@ -128,12 +128,12 @@ Profile
 		radiation = 0.000002222 // 0.008 rad/h
 	}
 
-	MODULE:NEEDS[ProfileDefault|ProfileClassic]
+	MODULE:NEEDS[ProfileRealismOverhaul]
 	{
 		name = ProcessController
 		resource = _RTG
 		title = RTG
-		capacity = 3.0
+		capacity = #$../MODULE[ModuleGenerator]/OUTPUT_RESOURCE[ElectricCharge]/rate$
 		running = true
 		toggle = false
 	}


### PR DESCRIPTION
Give it the right profile, and inherit capacity from RO's value

N.B. I haven't touched the Emitter module, no clue if its value is RO-plausible. None of the other RTGs have an Emitter at all.