### PR TITLE
Fix Regolith Compacter

### DIFF
--- a/GameData/KerbalismConfig/Profiles/ROKerbalism.cfg
+++ b/GameData/KerbalismConfig/Profiles/ROKerbalism.cfg
@@ -2478,6 +2478,18 @@ RESOURCE_DEFINITION
 		desc = A compacter that compresses <b>Regolith</b> into <b>Shielding</b> and places it on top of the habitats.
 		capacity = 1
 	}
+	+MODULE[ProcessController]:HAS[#title[Regolith?Compacter]]
+	{
+		@title ^= :$: (50%):
+	}
+	+MODULE[ProcessController]:HAS[#title[Regolith?Compacter]]
+	{
+		@title ^= :$: (20%):
+	}
+	+MODULE[ProcessController]:HAS[#title[Regolith?Compacter]]
+	{
+		@title ^= :$: (10%):
+	}
 
 	MODULE
 	{
@@ -2531,8 +2543,8 @@ RESOURCE_DEFINITION
 			MODULE
 			{
 				type = ProcessController
-				id_field = resource
-				id_value = _RegolithCompacter
+				id_field = title
+				id_value = Regolith Compacter
 			}
 			RESOURCE
 			{
@@ -2551,6 +2563,10 @@ RESOURCE_DEFINITION
 			{
 				@id_value ^= :$: (50%):
 			}
+			@MODULE:HAS[#type[ProcessController]]
+			{
+				@id_value ^= :$: (50%):
+			}
 		}
 		+SETUP[Regolith?Harvester]
 		{
@@ -2562,6 +2578,10 @@ RESOURCE_DEFINITION
 			{
 				@id_value ^= :$: (20%):
 			}
+			@MODULE:HAS[#type[ProcessController]]
+			{
+				@id_value ^= :$: (20%):
+			}
 		}
 		+SETUP[Regolith?Harvester]
 		{
@@ -2570,6 +2590,10 @@ RESOURCE_DEFINITION
 			@mass *= 0.2
 
 			@MODULE:HAS[#type[Harvester]]
+			{
+				@id_value ^= :$: (10%):
+			}
+			@MODULE:HAS[#type[ProcessController]]
 			{
 				@id_value ^= :$: (10%):
 			}


### PR DESCRIPTION
Got broken when adding the throttled Harvester configs; apparently
multiple SETUPs can't reference the same MODULE instance, only the
last reference "sticks".