### PR TITLE
Add Sabatier process to ISRU parts

### DIFF
--- a/GameData/KerbalismConfig/Profiles/ROKerbalism.cfg
+++ b/GameData/KerbalismConfig/Profiles/ROKerbalism.cfg
@@ -1446,6 +1446,14 @@ Supply
 		capacity = 12
 		running = true
 	}
+  	MODULE
+  	{
+		name = ProcessController
+		resource = _Sabatier
+		title = Sabatier process
+		capacity = 4 // 4x the chemical plant's
+		running = true
+	}
 
 	processConfigureExclude = true
 	MODULE
@@ -1604,6 +1612,21 @@ Supply
 				id_value = _WaterElectrolysis
 			}
 		}
+		SETUP
+		{
+			name = Sabatier Process
+			desc = <b>LqdHydrogen</b> and <b>CarbonDioxide</b> react with a nickel catalyst to produce <b>Water</b> and <b>LqdMethane</b>.
+			tech = advancedLifeSupport
+			mass = 0.16 // 2x the chemical plant's mass for 4x the throughput
+			cost = 100 //FIXME
+
+			MODULE
+			{
+				type = ProcessController
+				id_field = resource
+				id_value = _Sabatier
+			}
+		}
 	}
 }
 
@@ -1678,6 +1701,14 @@ Supply
 		resource = _WaterElectrolysis
 		title = Water Electrolysis
 		capacity = 60
+		running = true
+	}
+  	MODULE
+  	{
+		name = ProcessController
+		resource = _Sabatier
+		title = Sabatier process
+		capacity = 20 // 5x the mini-isru's
 		running = true
 	}
 
@@ -1838,6 +1869,22 @@ Supply
 				id_value = _WaterElectrolysis
 			}
 		}
+		SETUP
+		{
+			name = Sabatier Process
+			desc = <b>LqdHydrogen</b> and <b>CarbonDioxide</b> react with a nickel catalyst to produce <b>Water</b> and <b>LqdMethane</b>.
+			tech = advancedLifeSupport
+			mass = 0.4 // 2.5x the mini-isru's mass for 5x the throughput
+			cost = 250 //FIXME
+
+			MODULE
+			{
+				type = ProcessController
+				id_field = resource
+				id_value = _Sabatier
+			}
+		}
+
 	}
 }
 


### PR DESCRIPTION
scaled more or less following existing examples;
2x mass increase translates to 4x throughput increase
(actual mass increase factor is higher due to part mass)

ISRU has the SE-RWGS, which is much more efficient than
Sabatier IF you don't want water out of the process.
But if you do want water, chemical plant Sabatier was the
only option and very slow